### PR TITLE
wip: partitions

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.26.0-0"
 type: application
-version: 0.0.4
+version: 0.0.5
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/_helpers.tpl
+++ b/charts/adaptive/templates/_helpers.tpl
@@ -37,6 +37,9 @@ Control plane and harmony components full names
 {{- define "adaptive.harmony.settingsConfigMap.fullname"}}
 {{- printf "%s-settings-confmap" (include "adaptive.harmony.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end}}
+{{- define "adaptive.harmony.deployment.fullname"}}
+{{- printf "%s-dpl" (include "adaptive.harmony.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end}}
 
 
 {{/*
@@ -95,6 +98,11 @@ app.kubernetes.io/component: control-plane
 
 {{- define "adaptive.harmony.selectorLabels" -}}
 app.kubernetes.io/component: harmony
+{{ include "adaptive.sharedSelectorLabels" . }}
+{{- end }}
+
+{{- define "adaptive.harmony.deployment.selectorLabels" -}}
+app.kubernetes.io/component: harmony-dpl
 {{ include "adaptive.sharedSelectorLabels" . }}
 {{- end }}
 

--- a/charts/adaptive/templates/control-plane-dpl.yaml
+++ b/charts/adaptive/templates/control-plane-dpl.yaml
@@ -60,8 +60,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "adaptive.controlPlane.configSecret.fullname" . }}
                   key: dbUrl
-            - name: ADAPTIVE_HARMONY__URL
-              value: "http://{{ include "adaptive.harmony.service.fullname" . }}"
             - name: ADAPTIVE_SERVER__BIND
               value: "0.0.0.0:{{ $ports.http.containerPort }}"
             - name: ADAPTIVE_SERVER__ROOT_URL

--- a/charts/adaptive/templates/harmony-deployment.yaml
+++ b/charts/adaptive/templates/harmony-deployment.yaml
@@ -1,0 +1,150 @@
+{{- $harmonySettings := include "adaptive.harmony.settings" . | fromJson }}
+
+{{- if .Values.harmony.inferenceFleet }}
+{{- range $pool := .Values.harmony.inferenceFleet }}
+
+{{- $poolMerged := mergeOverwrite $.Values.harmony $pool }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "adaptive.harmony.deployment.fullname" $ }}-{{ $pool.name | snakecase }}
+  namespace: {{ $.Release.Namespace}}
+  labels:
+    {{- include "adaptive.labels" $ | nindent 4 }}
+    {{- include "adaptive.harmony.deployment.selectorLabels" $ | nindent 4 }}
+    inference-pool: {{ $pool.name | snakecase }}
+spec:
+  replicas: {{ $pool.replicaCount | default 1 | int }}
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "adaptive.harmony.deployment.selectorLabels" $ | nindent 6}}
+      inference-pool: {{ $pool.name | snakecase }}
+  template:
+    metadata:
+      {{- with $poolMerged.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "adaptive.labels" $ | nindent 8 }}
+        {{- include "adaptive.harmony.deployment.selectorLabels" $ | nindent 8 }}
+        inference-pool: {{ $pool.name | snakecase }}
+        {{- with $pool.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if $.Values.serviceAccount.name }}
+      serviceAccountName: {{ $.Values.serviceAccount.name }}
+      {{- end }}
+      nodeSelector:
+        {{- with $poolMerged.nodeSelector }}
+        {{ toYaml . }}
+        {{- end}}
+      tolerations:
+        - key: "nvidia.com/gpu"
+          operator: "Exists"
+          effect: "NoSchedule"
+      initContainers:
+      - name: init-permissions
+        image: busybox
+        command: ['sh', '-c', 'chown -R  1002:1000 {{ $harmonySettings.working_dir }} {{ $harmonySettings.shared_master_worker_folder }} {{ $harmonySettings.any_path_config.cloud_cache }}']
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - name: workdir-volume
+            mountPath: {{ $harmonySettings.working_dir }}
+          - name: cloud-cache-volume
+            mountPath: {{ $harmonySettings.any_path_config.cloud_cache }}
+      containers:
+        - name: harmony
+          image: "{{ include "adaptive.harmony.imageUri" $ }}"
+          imagePullPolicy: {{ $.Values.harmony.image.pullPolicy }}
+          resources:
+            limits:
+              {{- toYaml $poolMerged.resources.limits | nindent 14 }}
+              {{- if $poolMerged.gpusPerReplica}}
+              nvidia.com/gpu: {{ $poolMerged.gpusPerReplica }}
+              {{- end}}
+            requests:
+              {{- toYaml $poolMerged.resources.requests | nindent 14 }}
+              {{- if $poolMerged.gpusPerReplica }}
+              nvidia.com/gpu: {{ $poolMerged.gpusPerReplica }}
+              {{- end}}
+          ports:
+            {{- $ports := include "adaptive.harmony.ports" $ | fromJson }}
+            - containerPort: {{ $ports.http.containerPort }}
+              name: {{ $ports.http.name }}
+            - containerPort: {{ $ports.queue.containerPort }}
+              name: {{ $ports.queue.name }}
+            - containerPort: {{ $ports.torch.containerPort }}
+              name: {{ $ports.torch.name }} 
+          envFrom:
+            - secretRef:
+                name: {{ include "adaptive.harmony.configSecret.fullname" $ }}
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: ORDINAL
+              value: 0
+            - name: GPU_COUNT
+              value: "{{ $poolMerged.gpusPerReplica | default 1 }}"
+            - name: WORLD_SIZE
+              value: "{{ $poolMerged.gpusPerReplica | default 1 }}"
+            - name: MASTER_ADDR
+              value: "127.0.0.1"
+            - name: MASTER_PORT
+              value: "{{ $ports.torch.containerPort }}"
+            - name: QUEUE_PORT
+              value: "{{ $ports.queue.containerPort }}"
+            - name: CONTROL_PLANE_URL
+              value: "http://{{ include "adaptive.controlPlane.service.fullname" $ }}"
+            - name: GROUP
+              value: {{ $pool.name }}
+            - name: PARTITION_KEY
+              value: "$(MY_POD_NAME)"
+            - name: SERVICE_URL
+              value: "http://$(MY_POD_IP):{{ $ports.http.containerPort }}"
+            - name: ADAPTIVE_LOGGING_LEVEL
+              value: info
+            - name: ADAPTIVE_MODE
+              value: PROD
+            {{- if $poolMerged.extraEnvVars }}
+            {{- range $key, $value := $poolMerged.extraEnvVars }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+          volumeMounts:
+            - name: workdir-volume
+              mountPath: {{ $harmonySettings.working_dir }}
+            - name: cloud-cache-volume
+              mountPath: {{ $harmonySettings.any_path_config.cloud_cache }}
+            - name: harmony-settings-volume
+              mountPath: /opt/adaptive/harmony_settings/docker.json
+              subPath: docker.json
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        - name: cloud-cache-volume
+          emptyDir: {}
+        - name: workdir-volume
+          emptyDir: {}
+        - name: harmony-settings-volume
+          configMap:
+            name: {{ include "adaptive.harmony.settingsConfigMap.fullname" $ }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 8Gi
+
+{{- end }}
+{{- end }}

--- a/charts/adaptive/templates/harmony-statefulset.yaml
+++ b/charts/adaptive/templates/harmony-statefulset.yaml
@@ -89,6 +89,14 @@ spec:
               value: "{{ $ports.torch.containerPort }}"
             - name: QUEUE_PORT
               value: "{{ $ports.queue.containerPort }}"
+            - name: CONTROL_PLANE_URL
+              value: "http://{{ include "adaptive.controlPlane.service.fullname" . }}"
+            - name: GROUP
+              value: {{ .Values.harmony.group }}
+            - name: PARTITION_KEY
+              value: {{ .Values.harmony.partitionKey }}
+            - name: SERVICE_URL
+              value: "http://{{ include "adaptive.harmony.service.fullname" . }}"
             - name: ADAPTIVE_LOGGING_LEVEL
               value: info
             - name: ADAPTIVE_MODE

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -63,6 +63,9 @@ harmony:
     tag: harmony:latest   # Add the harmony image tag
     pullPolicy: Always
 
+  group: default # Visible name of the group for this statefulset
+  partitionKey: default-statefulset # Partition name, should be unique across other groups
+
   replicaCount: 1
 
   # Should be equal to, or a divisor of the # of GPUs on each node

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -63,8 +63,8 @@ harmony:
     tag: harmony:latest   # Add the harmony image tag
     pullPolicy: Always
 
-  group: default # Visible name of the group for this statefulset
-  partitionKey: default-statefulset # Partition name, should be unique across other groups
+  group: default   # Visible name of the group for this statefulset
+  partitionKey: default-statefulset   # Partition name, should be unique across other groups
 
   replicaCount: 1
 
@@ -91,7 +91,7 @@ harmony:
   podLabels: {}
   extraEnvVars: {}
 
-  inferenceFleet: [] # Uncomment to deploy new partitions to handle inference
+  inferenceFleet: []   # Uncomment to deploy new partitions to handle inference
   #   - name: "Inference Pool"
   #     replicaCount: 0
 

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -91,6 +91,10 @@ harmony:
   podLabels: {}
   extraEnvVars: {}
 
+  inferenceFleet: [] # Uncomment to deploy new partitions to handle inference
+  #   - name: "Inference Pool"
+  #     replicaCount: 0
+
 controlPlane:
   image:
     repository: adaptive-repository   # Add the Adaptive Repository you have been granted access to


### PR DESCRIPTION
Usage:

```yaml
harmony:
...

  inferenceFleet:
    - name: "Inference fleet A"
      replicaCount: 2
      gpusPerReplica: 4
      resources:
        limits:
          memory: 500Gi
    - name: "Fleet B"
      replicaCount: 4
      gpusPerReplica: 1
```

This would create 2 deployments:
- A with 2 replicas using 4 gpus per node
- B with 4 replicas using 1 gpu per node

Values for each deployment are inherited from `harmony` but can be overridden (cf `$poolMerged` in deployment)