### PR TITLE
:sparkles: add group capabilities

### DIFF
--- a/charts/adaptive/templates/harmony-deployment.yaml
+++ b/charts/adaptive/templates/harmony-deployment.yaml
@@ -109,6 +109,8 @@ spec:
               value: "http://{{ include "adaptive.controlPlane.service.fullname" $ }}"
             - name: GROUP
               value: {{ $pool.name }}
+            - name: GROUP_CAPABILITIES
+              value: "INFERENCE"
             - name: PARTITION_KEY
               value: "$(MY_POD_NAME)"
             - name: SERVICE_URL

--- a/charts/adaptive/templates/harmony-statefulset.yaml
+++ b/charts/adaptive/templates/harmony-statefulset.yaml
@@ -93,6 +93,8 @@ spec:
               value: "http://{{ include "adaptive.controlPlane.service.fullname" . }}"
             - name: GROUP
               value: {{ .Values.harmony.group }}
+            - name: GROUP_CAPABILITIES
+              value: "TRAINING,INFERENCE,EVALUATION"
             - name: PARTITION_KEY
               value: {{ .Values.harmony.partitionKey }}
             - name: SERVICE_URL


### PR DESCRIPTION
- add "GROUP_CAPABILITIES", it's a list of string separated by commas to indicate what a group is capable of doing:
  - "statefulset" => everything
  -  "deployment" => inference only