### PR TITLE
🐛 fix http endpoints

### DIFF
--- a/charts/adaptive/templates/_helpers.tpl
+++ b/charts/adaptive/templates/_helpers.tpl
@@ -118,6 +118,15 @@ Harmony ports
 }
 {{- end }}
 
+{{/*
+Harmony service HTTP endpoint
+*/}}
+{{- define "adaptive.harmony.httpEndpoint" -}}
+{{- $ports := fromJson (include "adaptive.harmony.ports" .) -}}
+{{- printf "http://%s:%d" (include "adaptive.harmony.service.fullname" .) (int $ports.http.port) }}
+{{- end }}
+
+
 {{- define "adaptive.oidc_providers" -}}
 [
   {{- range .Values.secrets.auth.oidc.providers -}}
@@ -144,6 +153,13 @@ Control plane ports
 {
   "http": {"name": "http", "containerPort": 9000}
 }
+{{- end }}
+
+{{/*
+Control plane HTTP endpoint
+*/}}
+{{- define "adaptive.controlPlane.httpEndpoint" -}}
+{{- printf "http://%s:%d" (include "adaptive.controlPlane.service.fullname" .) (int .Values.controlPlane.servicePort) }}
 {{- end }}
 
 {{/*

--- a/charts/adaptive/templates/harmony-deployment.yaml
+++ b/charts/adaptive/templates/harmony-deployment.yaml
@@ -116,7 +116,7 @@ spec:
             - name: QUEUE_PORT
               value: "{{ $ports.queue.containerPort }}"
             - name: CONTROL_PLANE_URL
-              value: "http://{{ include "adaptive.controlPlane.service.fullname" $ }}"
+              value: "{{ include "adaptive.controlPlane.httpEndpoint" $ }}"
             - name: GROUP
               value: {{ $pool.name }}
             - name: GROUP_CAPABILITIES

--- a/charts/adaptive/templates/harmony-statefulset.yaml
+++ b/charts/adaptive/templates/harmony-statefulset.yaml
@@ -100,7 +100,7 @@ spec:
             - name: QUEUE_PORT
               value: "{{ $ports.queue.containerPort }}"
             - name: CONTROL_PLANE_URL
-              value: "http://{{ include "adaptive.controlPlane.service.fullname" . }}"
+              value: "{{ include "adaptive.controlPlane.httpEndpoint" . }}"
             - name: GROUP
               value: {{ .Values.harmony.group }}
             - name: GROUP_CAPABILITIES
@@ -108,7 +108,7 @@ spec:
             - name: PARTITION_KEY
               value: {{ .Values.harmony.partitionKey }}
             - name: SERVICE_URL
-              value: "http://{{ include "adaptive.harmony.service.fullname" . }}"
+              value: "{{ include "adaptive.harmony.httpEndpoint" . }}"
             - name: ADAPTIVE_LOGGING_LEVEL
               value: info
             {{- if .Values.s3proxy.enabled }}


### PR DESCRIPTION
- current template assumes the service http endpoint is always. However.. happens that in AT&T , they overriden service port to 8000 and that broke the deployment .