### PR TITLE
🧱 change config for CONTROL_PLANE_URL

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.26.0-0"
 type: application
-version: 0.4.3
+version: 0.5.0
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/_helpers.tpl
+++ b/charts/adaptive/templates/_helpers.tpl
@@ -151,15 +151,17 @@ Control plane ports
 */}}
 {{- define "adaptive.controlPlane.ports" -}}
 {
-  "http": {"name": "http", "containerPort": 9000}
+  "http": {"name": "http", "containerPort": 9000},
+  "internal": {"name": "internal", "containerPort": 9009}
 }
 {{- end }}
 
 {{/*
-Control plane HTTP endpoint
+Control plane HTTP private endpoint
 */}}
-{{- define "adaptive.controlPlane.publicHttpEndpoint" -}}
-{{- printf "http://%s:%d" (include "adaptive.controlPlane.service.fullname" .) (int .Values.controlPlane.servicePort) }}
+{{- define "adaptive.controlPlane.privateHttpEndpoint" -}}
+{{- $ports := fromJson (include "adaptive.controlPlane.ports" .) -}}
+{{- printf "http://%s:%d" (include "adaptive.controlPlane.service.fullname" .) (int $ports.internal.containerPort) }}
 {{- end }}
 
 {{/*

--- a/charts/adaptive/templates/control-plane-svc.yaml
+++ b/charts/adaptive/templates/control-plane-svc.yaml
@@ -14,3 +14,6 @@ spec:
     - name: {{ $ports.http.name }}
       port: {{ .Values.controlPlane.servicePort | default 80 | int}}
       targetPort: {{ $ports.http.containerPort }}
+    - name: {{ $ports.internal.name }}
+      port: {{ $ports.internal.containerPort }}
+      targetPort: {{ $ports.internal.containerPort }}

--- a/charts/adaptive/templates/harmony-deployment.yaml
+++ b/charts/adaptive/templates/harmony-deployment.yaml
@@ -116,7 +116,7 @@ spec:
             - name: QUEUE_PORT
               value: "{{ $ports.queue.containerPort }}"
             - name: CONTROL_PLANE_URL
-              value: "{{ include "adaptive.controlPlane.publicHttpEndpoint" $ }}"
+              value: "{{ include "adaptive.controlPlane.privateHttpEndpoint" $ }}"
             - name: GROUP
               value: {{ $pool.name }}
             - name: GROUP_CAPABILITIES

--- a/charts/adaptive/templates/harmony-statefulset.yaml
+++ b/charts/adaptive/templates/harmony-statefulset.yaml
@@ -100,7 +100,7 @@ spec:
             - name: QUEUE_PORT
               value: "{{ $ports.queue.containerPort }}"
             - name: CONTROL_PLANE_URL
-              value: "{{ include "adaptive.controlPlane.publicHttpEndpoint" . }}"
+              value: "{{ include "adaptive.controlPlane.privateHttpEndpoint" . }}"
             - name: GROUP
               value: {{ .Values.harmony.group }}
             - name: GROUP_CAPABILITIES


### PR DESCRIPTION
Change in helm for compatibility with v0.5 . this is a breaking change, meaning starting from this version, older adaptive version cannot be used unless you add extraEnv override for control_plane_url en variable