### PR TITLE
:bug: fix harmony job log dir location

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.26.0-0"
 type: application
-version: 0.5.6
+version: 0.5.7
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/harmony-deployment.yaml
+++ b/charts/adaptive/templates/harmony-deployment.yaml
@@ -139,6 +139,8 @@ spec:
               value: info
             - name: ADAPTIVE_MODE
               value: PROD
+            - name: JOB_LOG_DIR
+              value: "{{ $harmonySettings.working_dir }}/job_logs"
             {{- if $poolMerged.extraEnvVars }}
             {{- range $key, $value := $poolMerged.extraEnvVars }}
             - name: {{ $key }}

--- a/charts/adaptive/templates/harmony-statefulset.yaml
+++ b/charts/adaptive/templates/harmony-statefulset.yaml
@@ -125,14 +125,14 @@ spec:
             {{- end }}
             - name: ADAPTIVE_MODE
               value: PROD
+            - name: JOB_LOG_DIR
+              value: "{{ $harmonySettings.working_dir }}/job_logs"
             {{- if .Values.mlflow.enabled }}
             - name: MLFLOW_TRACKING_URI
               value: "http://{{ include "adaptive.mlflow.service.fullname" . }}:{{ (include "adaptive.mlflow.ports" . | fromJson).http.port }}"
             {{- else if .Values.tensorboard.enabled }}
             - name: TENSORBOARD_LOGGING_DIR
               value: "/logdir"
-            - name: JOB_LOG_DIR
-              value: "{{ $harmonySettings.working_dir }}/job_logs"
             {{- end }}
             {{- if .Values.harmony.extraEnvVars }}
             {{- range $key, $value := .Values.harmony.extraEnvVars }}


### PR DESCRIPTION
env var `JOB_LOG_DIR` is necessary so the logs are written to a file that can be picked up by the alloy container