### PR TITLE
add otel collector

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.20.0
+version: 0.20.1
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/_helpers.tpl
+++ b/charts/adaptive/templates/_helpers.tpl
@@ -432,3 +432,33 @@ Generate individual database components - uses internal PostgreSQL if enabled, o
 {{- required "secrets.db.database is required!" .Values.secrets.db.database -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+OpenTelemetry Collector related helpers
+*/}}
+{{- define "adaptive.otelCollector.fullname" -}}
+{{- printf "%s-otel-collector" (include "adaptive.fullname" .) | trunc 30 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "adaptive.otelCollector.service.fullname" -}}
+{{- printf "%s-svc" (include "adaptive.otelCollector.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "adaptive.otelCollector.configMap.fullname" -}}
+{{- printf "%s-config" (include "adaptive.otelCollector.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "adaptive.otelCollector.selectorLabels" -}}
+app.kubernetes.io/component: otel-collector
+{{ include "adaptive.sharedSelectorLabels" . }}
+{{- end }}
+
+{{- define "adaptive.otelCollector.imageUri" -}}
+{{- printf "%s" .Values.otel_collector.imageUri }}
+{{- end }}
+
+{{- define "adaptive.otelCollector.ports" -}}
+{
+  "http": {"name": "http", "containerPort": 12345, "port": 12345}
+}
+{{- end }}

--- a/charts/adaptive/templates/otel-collector-confmap.yaml
+++ b/charts/adaptive/templates/otel-collector-confmap.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.otel_collector.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "adaptive.otelCollector.configMap.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adaptive.labels" . | nindent 4 }}
+    {{- include "adaptive.otelCollector.selectorLabels" . | nindent 4 }}
+data:
+  config.alloy: |
+    logging {
+      level  = "info"
+      format = "logfmt"
+    }
+{{- if .Values.otel_collector.additional_config }}
+
+{{ .Values.otel_collector.additional_config | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/adaptive/templates/otel-collector-dpl.yaml
+++ b/charts/adaptive/templates/otel-collector-dpl.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.otel_collector.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "adaptive.otelCollector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adaptive.labels" . | nindent 4 }}
+    {{- include "adaptive.otelCollector.selectorLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.otel_collector.replicaCount | default 1 | int }}
+  selector:
+    matchLabels:
+      {{- include "adaptive.otelCollector.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/otel-collector-confmap.yaml") . | sha256sum }}
+        {{- with .Values.otel_collector.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "adaptive.labels" . | nindent 8 }}
+        {{- include "adaptive.otelCollector.selectorLabels" . | nindent 8 }}
+        {{- with .Values.otel_collector.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
+      {{- with .Values.otel_collector.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.otel_collector.tolerations }}
+      tolerations:
+        {{- toYaml .Values.otel_collector.tolerations | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: alloy
+          image: "{{ include "adaptive.otelCollector.imageUri" . }}"
+          imagePullPolicy: {{ .Values.otel_collector.image.pullPolicy }}
+          args:
+            - "run"
+            - "--server.http.listen-addr=0.0.0.0:{{ (include "adaptive.otelCollector.ports" . | fromJson).http.containerPort }}"
+            - "--storage.path=/var/lib/alloy/data"
+            - "/etc/alloy/config.alloy"
+          ports:
+            {{- $ports := include "adaptive.otelCollector.ports" . | fromJson }}
+            - containerPort: {{ $ports.http.containerPort }}
+              name: {{ $ports.http.name }}
+              protocol: TCP
+          {{- if .Values.otel_collector.resources }}
+          resources:
+            {{- toYaml .Values.otel_collector.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: alloy-config
+              mountPath: /etc/alloy
+            - name: alloy-data
+              mountPath: /var/lib/alloy/data
+            {{- if .Values.otel_collector.extraVolumeMounts }}
+            {{- toYaml .Values.otel_collector.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+          {{- if .Values.otel_collector.extraEnvVars }}
+          env:
+            {{- range $key, $value := .Values.otel_collector.extraEnvVars }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+      volumes:
+        - name: alloy-config
+          configMap:
+            name: {{ include "adaptive.otelCollector.configMap.fullname" . }}
+        - name: alloy-data
+          emptyDir: {}
+        {{- if .Values.otel_collector.extraVolumes }}
+        {{- toYaml .Values.otel_collector.extraVolumes | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/adaptive/templates/otel-collector-svc.yaml
+++ b/charts/adaptive/templates/otel-collector-svc.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.otel_collector.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "adaptive.otelCollector.service.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adaptive.labels" . | nindent 4 }}
+    {{- include "adaptive.otelCollector.selectorLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.otel_collector.service.type | default "ClusterIP" }}
+  ports:
+    {{- $ports := include "adaptive.otelCollector.ports" . | fromJson }}
+    - port: {{ $ports.http.port }}
+      targetPort: {{ $ports.http.containerPort }}
+      protocol: TCP
+      name: {{ $ports.http.name }}
+  selector:
+    {{- include "adaptive.otelCollector.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -564,6 +564,69 @@ alloy:
       cpu: 100m
       memory: 512Mi
 
+otel_collector:
+  # Set to true to deploy a standalone OpenTelemetry Collector (Grafana Alloy) instance
+  enabled: false
+
+  imageUri: grafana/alloy:latest
+  image:
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  # Service configuration
+  service:
+    type: ClusterIP
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 512Mi
+
+  # Additional Alloy configuration to append to the default logging configuration
+  # The default config includes logging level set to "info" with "logfmt" format
+  # See Grafana Alloy documentation: https://grafana.com/docs/alloy/
+  additional_config: ""
+  # Example configuration:
+  # additional_config: |
+  #   prometheus.scrape "default" {
+  #     targets = [
+  #       {"__address__" = "localhost:9090"},
+  #     ]
+  #     forward_to = [prometheus.remote_write.default.receiver]
+  #   }
+  #
+  #   prometheus.remote_write "default" {
+  #     endpoint {
+  #       url = "http://prometheus:9090/api/v1/write"
+  #     }
+  #   }
+
+  # Node selection and tolerations
+  nodeSelector: {}
+  tolerations: []
+
+  podAnnotations: {}
+  podLabels: {}
+  extraEnvVars: {}
+  extraVolumes: []
+  # Example:
+  # extraVolumes:
+  #   - name: varlog
+  #     hostPath:
+  #       path: /var/log
+
+  # Extra volume mounts
+  extraVolumeMounts: []
+  # Example:
+  # extraVolumeMounts:
+  #   - name: varlog
+  #     mountPath: /var/log
+  #     readOnly: true
+
 # Optional: This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 


### PR DESCRIPTION
Draft PR for now.
Goal is to add an OTEL collector in the stack. Goal would be to simplify log collection:
- all components push to the otel collector
- collector redirects the log stream to some sink: by default loki 
- collector can be configured to send logs to somewhere else too (global collector, cloudwatch, other)

