### PR TITLE
Add hostPath and memory persistence types for LGTM stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,8 +726,10 @@ lgtm:
 
   persistence:
     enabled: false    # Set to true to persist data across restarts
+    type: pvc         # pvc | hostPath | memory
     size: 10Gi
     storageClass: ""  # Use default storage class if empty
+    hostPath: /tmp/lgtm-data  # Only used when type: hostPath
 
   # Grafana environment variables
   env:
@@ -1067,14 +1069,39 @@ harmony:
 
 ### LGTM Stack
 
-By default, LGTM data (Grafana dashboards, Loki logs, Tempo traces) is not persisted. Enable persistence to retain data across pod restarts:
+By default, LGTM data (Grafana dashboards, Loki logs, Tempo traces) is not persisted. Enable persistence to retain data across pod restarts.
+
+Three persistence types are available:
+
+- **pvc** (default) — uses a PersistentVolumeClaim
+- **hostPath** — mounts a directory from the host node's filesystem
+- **memory** — uses a RAM-backed tmpfs (fast but lost on pod restart)
 
 ```yaml
+# PVC (default)
 lgtm:
   persistence:
     enabled: true
+    type: pvc
     size: 10Gi
     storageClass: "your-storage-class-name"
+```
+
+```yaml
+# Host path
+lgtm:
+  persistence:
+    enabled: true
+    type: hostPath
+    hostPath: /mnt/data/lgtm
+```
+
+```yaml
+# Memory (tmpfs)
+lgtm:
+  persistence:
+    enabled: true
+    type: memory
 ```
 
 ---

--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.38.5
+version: 0.38.6
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/lgtm-dpl.yaml
+++ b/charts/adaptive/templates/lgtm-dpl.yaml
@@ -57,8 +57,18 @@ spec:
       volumes:
         - name: data
           {{- if .Values.lgtm.persistence.enabled }}
+          {{- $type := .Values.lgtm.persistence.type | default "pvc" }}
+          {{- if eq $type "pvc" }}
           persistentVolumeClaim:
             claimName: {{ include "adaptive.lgtm.pvc.fullname" . }}
+          {{- else if eq $type "hostPath" }}
+          hostPath:
+            path: {{ .Values.lgtm.persistence.hostPath }}
+            type: DirectoryOrCreate
+          {{- else if eq $type "memory" }}
+          emptyDir:
+            medium: Memory
+          {{- end }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/charts/adaptive/templates/lgtm-pvc.yaml
+++ b/charts/adaptive/templates/lgtm-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.lgtm.enabled .Values.lgtm.persistence.enabled }}
+{{- if and .Values.lgtm.enabled .Values.lgtm.persistence.enabled (eq (.Values.lgtm.persistence.type | default "pvc") "pvc") }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -766,8 +766,15 @@ lgtm:
 
   persistence:
     enabled: false
+    # type: pvc | hostPath | memory
+    # pvc - uses a PersistentVolumeClaim (default)
+    # hostPath - mounts a directory from the host node
+    # memory - uses an emptyDir backed by RAM (tmpfs)
+    type: pvc
     size: 10Gi
     storageClass: ""
+    # hostPath - path on the host node (only used when type: hostPath)
+    hostPath: /tmp/lgtm-data
 
   env:
     GF_AUTH_ANONYMOUS_ENABLED: true


### PR DESCRIPTION
## Summary

- Add `lgtm.persistence.type` field supporting three options: `pvc` (default), `hostPath`, and `memory`
- `hostPath` mounts a directory from the host node's filesystem
- `memory` uses a RAM-backed tmpfs (emptyDir with `medium: Memory`)
- PVC is only created when type is `pvc`
- Bump chart version to 0.38.6

## Test plan

- [ ] `helm template` with `type: pvc` — PVC created, volume references PVC
- [ ] `helm template` with `type: hostPath` — no PVC, volume uses hostPath
- [ ] `helm template` with `type: memory` — no PVC, volume uses emptyDir with Memory medium
- [ ] `helm template` without persistence enabled — emptyDir (no medium)

🤖 Generated with [Claude Code](https://claude.com/claude-code)