### PR TITLE
feat: Add extraObjects for arbitrary Kubernetes manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A Helm Chart to deploy Adaptive Engine.
   - [Per-Pool Node Selectors](#per-pool-node-selectors)
 - [Storage and Persistence](#storage-and-persistence)
   - [LGTM Stack](#lgtm-stack)
+- [Extra Objects](#extra-objects)
 - [Cloud specific information](#cloud-specific-information)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -1303,6 +1304,30 @@ lgtm:
     enabled: true
     size: 10Gi
     storageClass: "your-storage-class-name"
+```
+
+---
+
+## Extra Objects
+
+You can create arbitrary Kubernetes resources by adding them to the `extraObjects` list. Each item is passed through `tpl`, so Helm template expressions are supported. Items can be YAML objects or multiline strings (useful for templating field names).
+
+```yaml
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: my-extra-config
+    data:
+      key: value
+  - |
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: my-extra-secret
+      data:
+        password: {{ "secret" | b64enc | quote }}
 ```
 
 ---

--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.44.0
+version: 0.45.0
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/extra-objects.yaml
+++ b/charts/adaptive/templates/extra-objects.yaml
@@ -1,0 +1,10 @@
+{{- range .Values.extraObjects }}
+{{- if . }}
+---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
+{{ tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -944,3 +944,22 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+# Create extra Kubernetes manifests via values.
+# Each item is passed through `tpl` so Helm template expressions are supported.
+# Items can be YAML objects or multiline strings (useful for templating field names).
+extraObjects: []
+# - apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: extra-config
+#   data:
+#     key: value
+# - |
+#     apiVersion: v1
+#     kind: Secret
+#     type: Opaque
+#     metadata:
+#       name: extra-secret
+#     data:
+#       password: {{ "secret" | b64enc | quote }}


### PR DESCRIPTION
## Summary                                                        
  - Add `extraObjects` values field to create arbitrary Kubernetes resources via the chart                                                                   
  - Each item is passed through `tpl` so Helm template expressions are supported                                                                             
  - Items can be YAML objects or multiline strings (useful for templating field names)                                                                         
  - Bump chart version to 0.44.0                                                                                                                               
                                                                                                                                                               
  ## Test plan                                                                                                                                                 
  - [ ] `helm template` with object-type extraObjects renders correctly                                                                                   
  - [ ] `helm template` with multiline string extraObjects renders correctly                                                                    
  - [ ] `helm template` with empty/default extraObjects produces no extra resources                                                                          
  - [ ] `ct lint` passes