### PR TITLE
🛂 Grant control-plane SA create on kai.scheduler Topologies

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.46.0
+version: 0.46.1
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/control-plane-role.yaml
+++ b/charts/adaptive/templates/control-plane-role.yaml
@@ -88,8 +88,9 @@ rules:
   - apiGroups: ["scheduling.run.ai"]
     resources: ["policies"]
     verbs: ["get", "list", "watch"]
-  # kueue.x-k8s.io — Topology CRD for GPU topology awareness
-  - apiGroups: ["kueue.x-k8s.io"]
+  # kai.scheduler — Topology CRD for GPU topology awareness
+  # (KAI v0.14+ ships its own Topology CRD; earlier versions reused Kueue's at kueue.x-k8s.io)
+  - apiGroups: ["kai.scheduler"]
     resources: ["topologies"]
     verbs: ["create"]
 ---


### PR DESCRIPTION
## Summary

- KAI v0.14 ships its own `Topology` CRD at `kai.scheduler/v1alpha1`; earlier versions reused Kueue's at `kueue.x-k8s.io`.
- Concorde's starburst client was switched to `kai.scheduler` (see the starburst/crds.rs change). The `adaptive-controlplane-clusterrole` must follow so `ensure_exists()` can create the Topology.
- Without this, `createInferencePartition` fails on Fessenheim with:
  `topologies.kai.scheduler is forbidden: User "system:serviceaccount:adaptive:serviceaccount.adaptive-ml.com" cannot create resource "topologies" in API group "kai.scheduler" at the cluster scope`.

## Test plan

- [ ] `ct lint` / CI helm-diff passes
- [ ] `publish-pr.yml` publishes `0.0.0-sha.<short-sha>` to GHCR OCI registry
- [ ] Bump `argocd/adaptive-fessenheim/adaptive/config.yaml` chartVersion in `k8s-infrastructure` to the new sha tag
- [ ] After Argo sync on Fessenheim, `kubectl get clusterrole adaptive-controlplane-clusterrole -o yaml | grep -A4 kai.scheduler` shows the `topologies create` rule
- [ ] Retry `createInferencePartition` mutation from the UI — succeeds
- [ ] `kubectl get topologies.kai.scheduler same-node-topology -o yaml` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)