### PR TITLE
fix(harmony): advertise stable per-pod DNS to Concorde (PS-4521)

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.48.1
+version: 0.48.2
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/harmony-statefulset.yaml
+++ b/charts/adaptive/templates/harmony-statefulset.yaml
@@ -153,7 +153,11 @@ spec:
               value: {{ $pool.capabilities | default "JOB,INFERENCE" | quote }}
             - name: PARTITION_KEY
               value: "{{ $pool.name | lower | replace " " "-" | replace "_" "-" }}"
-            - name: SERVICE_URL
+            # Stable per-pod DNS for the cadence-master pod (ordinal 0). Concorde
+            # stores this in `harmony_group.info.url` and recipes derive their
+            # harmony WS endpoint from it; pinning to a Service-managed name
+            # instead of the peer pod IP keeps it valid across pod restarts.
+            - name: ADVERTISED_URL
               value: "http://{{ include "adaptive.harmony.computePool.fullname" (dict "root" $root "pool" $pool) }}-0.{{ include "adaptive.harmony.computePool.headlessService.fullname" (dict "root" $root "pool" $pool) }}:{{ $ports.http.containerPort }}"
             - name: ADAPTIVE_LOGGING_LEVEL
               value: info


### PR DESCRIPTION
## Summary
- Rename `SERVICE_URL` → `ADVERTISED_URL` on the harmony StatefulSet so harmony-launcher actually consumes it.
- Bump chart to `0.48.2`.

## Background

Linear: [PS-4521](https://linear.app/adaptive-ml/issue/PS-4521/checkpoint-promotion-to-model-stays-pending-in-prod)

`SERVICE_URL` was added to this template in Feb 2025 (`1ec0a0e`, "wip: partitions") alongside the partition work, when harmony-launcher read it via `#[arg(long, env = "SERVICE_URL")]`. That arg was deleted in Nov 2025 (adaptive#2731 — "improve mangrove registration to concorde"), which switched mangrove to send only `service_port` and let Concorde fall back to the WS peer IP. The chart has been setting an env var nothing reads ever since.

In Apr 2026 (adaptive#4586 / PS-4469) an override path was reintroduced under a new name: `ADVERTISED_URL`. Mangrove now passes it as a query param and Concorde stores it in `harmony_group.info.url`. Until the chart starts setting that name, prod registrations still fall back to peer pod IP — which goes stale on pod restart and bakes a dead address into every recipe sandbox launched against the partition. That's the visible failure in PS-4521: `unity::client` retrying `ws://<old-pod-ip>:50053` for 16+ hours.

The value was already correct (`<sts>-0.<headless-svc>:<http-port>` — pod-0 is the cadence-master, the only pod that registers). Just renaming the var lights up the existing wiring.

## Test plan
- [ ] `helm template adaptive ./charts/adaptive -f <prod-values>` shows `ADVERTISED_URL` set per compute pool.
- [ ] After deploy in staging, verify `harmony_group.info.url` resolves to the headless Service DNS, not a pod IP.
- [ ] Restart a Mangrove pod; confirm `info.url` does not change and existing recipes keep connecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)