### PR TITLE
fix(otel): default to empty collector pipelines

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.49.0
+version: 0.49.1
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -597,19 +597,21 @@ otelCollector:
   # Available processors: [memory_limiter, batch, resource]
   # Note: The 'resource' processor is only available when resourceAttributes.extra is configured
   # Note: deployment.environment.name is now set via OTEL_RESOURCE_ATTRIBUTES env var on application pods
-  pipelines: |
-    traces:
-      receivers: [otlp]
-      processors: [memory_limiter, batch]
-      exporters: [debug]
-    metrics:
-      receivers: [otlp, prometheus]
-      processors: [memory_limiter, batch]
-      exporters: [debug]
-    logs:
-      receivers: [otlp]
-      processors: [memory_limiter, batch]
-      exporters: [debug]
+  # Example (sends everything to the debug exporter):
+  # pipelines: |
+  #   traces:
+  #     receivers: [otlp]
+  #     processors: [memory_limiter, batch]
+  #     exporters: [debug]
+  #   metrics:
+  #     receivers: [otlp, prometheus]
+  #     processors: [memory_limiter, batch]
+  #     exporters: [debug]
+  #   logs:
+  #     receivers: [otlp]
+  #     processors: [memory_limiter, batch]
+  #     exporters: [debug]
+  pipelines: ""
 
 mlflow:
   # If set to true, jobs will use MLflow for experiment tracking

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -597,21 +597,20 @@ otelCollector:
   # Available processors: [memory_limiter, batch, resource]
   # Note: The 'resource' processor is only available when resourceAttributes.extra is configured
   # Note: deployment.environment.name is now set via OTEL_RESOURCE_ATTRIBUTES env var on application pods
-  # Example (sends everything to the debug exporter):
-  # pipelines: |
-  #   traces:
-  #     receivers: [otlp]
-  #     processors: [memory_limiter, batch]
-  #     exporters: [debug]
-  #   metrics:
-  #     receivers: [otlp, prometheus]
-  #     processors: [memory_limiter, batch]
-  #     exporters: [debug]
-  #   logs:
-  #     receivers: [otlp]
-  #     processors: [memory_limiter, batch]
-  #     exporters: [debug]
-  pipelines: ""
+  pipelines: |
+    # Example: send everything to the debug exporter
+    # traces:
+    #   receivers: [otlp]
+    #   processors: [memory_limiter, batch]
+    #   exporters: [debug]
+    # metrics:
+    #   receivers: [otlp, prometheus]
+    #   processors: [memory_limiter, batch]
+    #   exporters: [debug]
+    # logs:
+    #   receivers: [otlp]
+    #   processors: [memory_limiter, batch]
+    #   exporters: [debug]
 
 mlflow:
   # If set to true, jobs will use MLflow for experiment tracking


### PR DESCRIPTION
## Summary
- Ship an empty `otelCollector.pipelines` by default; keep the previous debug-exporter pipelines as a commented example in `values.yaml`.
- Bump chart version to 0.49.1.

When `lgtm.enabled` (default) is on, the LGTM pipelines are still injected by the template, so the dev observability stack keeps working out of the box. Users opt into their own pipelines (e.g. forwarding to an external OTLP backend) by uncommenting/editing the example.

## Test plan
- [ ] `helm template adaptive ./charts/adaptive -f .github/test-values-base.yaml` renders successfully (LGTM pipelines present, user pipelines empty)
- [ ] `ct lint --target-branch main` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)