### PR TITLE
ci: ship README and UPGRADE inside the published chart

### DIFF
--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -33,6 +33,13 @@ jobs:
         id: sha
         run: echo "short=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
+      - name: Copy README and UPGRADE into chart
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          CHART_NAME: ${{ matrix.chart.name }}
+        run: |
+          cp README.md UPGRADE.md "charts/${CHART_NAME}/"
+
       - name: Publish Chart
         if: steps.changes.outputs.changed == 'true'
         uses: appany/helm-oci-chart-releaser@v0.5.0

--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -39,6 +39,8 @@ jobs:
           CHART_NAME: ${{ matrix.chart.name }}
         run: |
           cp README.md UPGRADE.md "charts/${CHART_NAME}/"
+          mkdir -p "charts/${CHART_NAME}/docs"
+          cp docs/azure.md "charts/${CHART_NAME}/docs/azure.md"
 
       - name: Publish Chart
         if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,8 @@ jobs:
           CHART_NAME: ${{ matrix.chart.name }}
         run: |
           cp README.md UPGRADE.md "charts/${CHART_NAME}/"
+          mkdir -p "charts/${CHART_NAME}/docs"
+          cp docs/azure.md "charts/${CHART_NAME}/docs/azure.md"
 
       - name: Publish Chart
         if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,9 +42,18 @@ jobs:
       - name: Read Chart Version
         if: steps.changes.outputs.changed == 'true'
         id: chart_version
+        env:
+          CHART_NAME: ${{ matrix.chart.name }}
         run: |
-          VERSION=$(yq eval '.version' charts/${{ matrix.chart.name }}/Chart.yaml)
+          VERSION=$(yq eval '.version' "charts/${CHART_NAME}/Chart.yaml")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Copy README and UPGRADE into chart
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          CHART_NAME: ${{ matrix.chart.name }}
+        run: |
+          cp README.md UPGRADE.md "charts/${CHART_NAME}/"
 
       - name: Publish Chart
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Summary
- `README.md` and `UPGRADE.md` live at the repo root (so GitHub renders them on the landing page), but Helm's OCI publisher only packages files under `charts/adaptive/`. As a result, `helm pull oci://ghcr.io/adaptive-ml/adaptive` produces a tarball with no docs — consumers have to come back to GitHub to find them.
- This adds a small `cp README.md UPGRADE.md charts/<chart>/` step in both `publish.yml` and `publish-pr.yml` before `appany/helm-oci-chart-releaser` runs, so the docs ship inside the chart while the repo root stays the source of truth.

No duplication on disk: nothing is committed to `charts/adaptive/`. The copy happens at package time in CI.

- nice devx: makes `helm show readme oci://ghcr.io/adaptive-ml/adaptive` work !!

## Test plan
- [ ] Merge → next publish on `main` (triggered by a chart change) produces a tarball where `tar tzf adaptive-<ver>.tgz | grep -E 'README\.md|UPGRADE\.md'` returns both files.
- [ ] On this PR, `publish-pr.yml` runs and the resulting `0.0.0-sha.<short>` chart includes the docs.
- [ ] `helm show readme oci://ghcr.io/adaptive-ml/adaptive --version <new-ver>` returns the README contents.