### PR TITLE
☢️ feat(operator): expose gang bin-packing & inter-node fabric config

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.49.1
+version: 0.49.2
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/operator-gang-config-confmap.yaml
+++ b/charts/adaptive/templates/operator-gang-config-confmap.yaml
@@ -13,11 +13,19 @@ data:
   HARMONY_IMAGE_REPO: {{ .Values.harmony.image.repository | quote }}
   RECIPE_RUNNER_IMAGE_REPO: {{ .Values.sandkasten.recipeRunner.repository | quote }}
   {{- end }}
-  # Harmony pod resources (CPU/memory requests and limits for gang-spawned pods)
+  # Harmony pod resources (CPU/memory requests and limits — applied per GPU,
+  # multiplied by per-pod GPU count by the operator)
   CPU_REQUESTS: {{ .Values.adaptiveOperator.resources.requests.cpu | quote }}
   MEMORY_REQUESTS: {{ .Values.adaptiveOperator.resources.requests.memory | quote }}
   CPU_LIMITS: {{ .Values.adaptiveOperator.resources.limits.cpu | quote }}
   MEMORY_LIMITS: {{ .Values.adaptiveOperator.resources.limits.memory | quote }}
+  # Gang bin-packing: pack N-GPU gangs into full-node pods so NVLink works
+  # intra-pod and inter-node fabric is requested only on multi-node packs.
+  GPUS_PER_NODE: {{ .Values.adaptiveOperator.gpusPerNode | quote }}
+  HARMONY_INTERCONNECT: {{ .Values.adaptiveOperator.interconnect | quote }}
+  {{- if eq .Values.adaptiveOperator.interconnect "efa" }}
+  EFAS_PER_NODE: {{ .Values.adaptiveOperator.efasPerNode | quote }}
+  {{- end }}
   {{- if .Values.adaptiveOperator.customLabels }}
   CUSTOM_LABELS: {{ .Values.adaptiveOperator.customLabels | toJson | quote }}
   {{- end }}

--- a/charts/adaptive/templates/operator-gang-config-confmap.yaml
+++ b/charts/adaptive/templates/operator-gang-config-confmap.yaml
@@ -1,3 +1,16 @@
+{{- /* ── Gang bin-packing config validation ────────────────────────────── */ -}}
+{{- $validInterconnects := list "none" "efa" "infiniband" -}}
+{{- if not (has .Values.adaptiveOperator.interconnect $validInterconnects) -}}
+{{- fail (printf "adaptiveOperator.interconnect must be one of %v, got %q" $validInterconnects .Values.adaptiveOperator.interconnect) -}}
+{{- end -}}
+{{- if not (gt (int .Values.adaptiveOperator.gpusPerNode) 0) -}}
+{{- fail (printf "adaptiveOperator.gpusPerNode must be > 0, got %v" .Values.adaptiveOperator.gpusPerNode) -}}
+{{- end -}}
+{{- if eq .Values.adaptiveOperator.interconnect "efa" -}}
+{{- if not (gt (int .Values.adaptiveOperator.efasPerNode) 0) -}}
+{{- fail (printf "adaptiveOperator.efasPerNode must be > 0 when interconnect=\"efa\", got %v" .Values.adaptiveOperator.efasPerNode) -}}
+{{- end -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -247,8 +247,35 @@ adaptiveOperator:
   # Comma-separated glob patterns for allowed harmony image tags
   # Empty means no user choice — the server's own tag is used
   harmonyImageTagsWhitelist: ""
+  # ── Gang bin-packing & inter-node fabric ──────────────────────────────
+  # Drives how the operator packs N-GPU gangs into pods. With these set,
+  # multi-node gangs use full-node pods so NVLink works intra-pod and the
+  # inter-node fabric (EFA / Infiniband) is requested only when actually
+  # spanning nodes.
+  #
+  # Packing rule for a job requesting N GPUs total:
+  #   - N <= gpusPerNode  → one pod with all N GPUs (no fabric resource)
+  #   - N >  gpusPerNode  → ceil(N/gpusPerNode) pods of size gpusPerNode
+  #                         (last pod takes the remainder), fabric attached
+  #                         to every pod
+  #
+  # GPUs per node in the target cluster (default 8: p4d/p5/p4de/A100/H100/H200 nodes).
+  gpusPerNode: 8
+  # Inter-node fabric. One of: "none" | "efa" | "infiniband"
+  #   - none        — no extra resource requested (NCCL falls back to TCP)
+  #   - efa         — requests vpc.amazonaws.com/efa, scaled per pod
+  #                   (requires efasPerNode below; AWS p4d=4, p5=32)
+  #   - infiniband  — requests nvidia.com/hostdev (one HCA per GPU in the pod)
+  interconnect: "none"
+  # EFAs per node (required iff interconnect=efa). The operator allocates
+  # ceil(podGpus * efasPerNode / gpusPerNode) per pod, so full-node pods get
+  # the full count and remainder pods get a proportional share.
+  efasPerNode: 0
   # Extra Kubernetes extended resources to request per GPU on gang-spawned harmony pods
-  # Used for device-plugin-managed resources beyond nvidia.com/gpu (which is set automatically)
+  # Used for device-plugin-managed resources beyond nvidia.com/gpu (which is set automatically).
+  # Note: when interconnect is "efa" or "infiniband", the corresponding fabric resource
+  # (vpc.amazonaws.com/efa or nvidia.com/hostdev) is computed automatically. Any entry
+  # listed here overrides the computed value for the same key.
   # Example:
   #   - name: nvidia.com/hostdev
   #     value: "1"


### PR DESCRIPTION
## Summary

Adds three new gang ConfigMap keys consumed by [`k8s-operator`](https://github.com/adaptive-ml/adaptive/tree/fix/harmony-gang-stable-master-addr) (operator-side change in `ae62eafe4 🐛 Change packing logic to fit with EFA/IB`):

- **`GPUS_PER_NODE`** (default `8`) — drives gang bin-packing. For a workload of `N` GPUs:
  - `N <= GPUS_PER_NODE` → one pod with all `N` GPUs (NVLink intra-pod, no fabric resource needed)
  - `N > GPUS_PER_NODE` → `ceil(N / GPUS_PER_NODE)` pods with `GPUS_PER_NODE` GPUs each + one remainder pod with the leftover, fabric resource attached
- **`HARMONY_INTERCONNECT`** (default `"none"`) — one of `none` | `efa` | `infiniband`. Only emitted as a per-pod resource on multi-node packs.
  - `efa` → `vpc.amazonaws.com/efa` per pod, scaled as `ceil(podGpus * EFAS_PER_NODE / GPUS_PER_NODE)`
  - `infiniband` → `nvidia.com/hostdev = podGpus` (one HCA per GPU in the pod)
- **`EFAS_PER_NODE`** — emitted only when `HARMONY_INTERCONNECT="efa"`.

CPU/memory in the existing `CPU_REQUESTS`/`MEMORY_REQUESTS`/`CPU_LIMITS`/`MEMORY_LIMITS` keys are now interpreted as **per-GPU** values and multiplied by per-pod GPU count by the operator. The values already documented as "per GPU" in `values.yaml` line 239.

## Motivation

Today the operator forces 1-GPU-per-pod for gangs. On AWS EFA clusters this breaks two things:

1. **NVLink is wasted intra-node** — NCCL between 1-GPU pods on the same node falls back to SHM/CUDA-IPC (or net plugin on EFA), missing the NVLink fast path.
2. **EFA fails on intra-node peers** — the OFI/EFA plugin can't insert intra-node peers into its address vector when "peers" share the same physical NIC, leading to setup failures.

After this change, multi-GPU gangs that fit in one node use a single multi-GPU pod (NVLink works), and multi-node gangs use full-node pods with the right fabric resource attached only on the inter-node hop.

## Backward compatibility

Defaults preserve existing behavior for clusters that don't opt in:
- `interconnect: none` → no fabric resource attached on any pod.
- Existing `extraResources` entries still work and override the computed fabric value for the same key.

The packing itself (1 pod with N GPUs when N <= 8, otherwise full-node split) is a behavioral change in the operator binary, not gated by the chart values. Existing operator deployments that don't update will continue to get 1-pod-per-GPU behavior.

## Rendered output

Default values:
```yaml
GPUS_PER_NODE: "8"
HARMONY_INTERCONNECT: "none"
# EFAS_PER_NODE omitted
```

EFA on AWS p5 (8 GPUs / 32 EFAs per node):
```yaml
adaptiveOperator:
  interconnect: efa
  efasPerNode: 32
```
```yaml
GPUS_PER_NODE: "8"
HARMONY_INTERCONNECT: "efa"
EFAS_PER_NODE: "32"
```

Infiniband:
```yaml
adaptiveOperator:
  interconnect: infiniband
```
```yaml
GPUS_PER_NODE: "8"
HARMONY_INTERCONNECT: "infiniband"
# EFAS_PER_NODE omitted
```

## Test plan

- [x] `helm lint charts/adaptive -f .github/test-values-base.yaml` passes
- [x] `helm template` renders correctly for default, `efa`, and `infiniband` cases (no EFAS_PER_NODE on non-efa)
- [ ] Deploy to a multi-node EFA cluster and verify gang pods get the right `vpc.amazonaws.com/efa` request per pod
- [ ] Deploy to an Infiniband cluster and verify `nvidia.com/hostdev` request matches pod GPU count
- [ ] Verify existing single-cluster / sub-node deployments are unaffected (interconnect=none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)