### PR TITLE
feat(rbac): allow control-plane to watch configmaps for live reload

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.49.2
+version: 0.50.0
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/control-plane-role.yaml
+++ b/charts/adaptive/templates/control-plane-role.yaml
@@ -24,10 +24,13 @@ rules:
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["create", "delete"]
-  # core/v1 ConfigMaps — read config data
+  # core/v1 ConfigMaps — read config data + live-watch harmony-gang-config
+  # (PS-4618). `list` is required by kube-rs' list-then-watch; RBAC does not
+  # honor `resourceNames` for list, so the rule grants list/watch on
+  # configmaps in this namespace.
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
   # apps/v1 Deployments — inference partition lifecycle (create, resize, annotate, delete)
   - apiGroups: ["apps"]
     resources: ["deployments"]

--- a/charts/adaptive/templates/control-plane-role.yaml
+++ b/charts/adaptive/templates/control-plane-role.yaml
@@ -25,9 +25,6 @@ rules:
     resources: ["services"]
     verbs: ["create", "delete"]
   # core/v1 ConfigMaps — read config data + live-watch harmony-gang-config
-  # (PS-4618). `list` is required by kube-rs' list-then-watch; RBAC does not
-  # honor `resourceNames` for list, so the rule grants list/watch on
-  # configmaps in this namespace.
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Summary

- Bumps the `configmaps` rule in the control-plane Role from `verbs: [get]` to `verbs: [get, list, watch]`.
- Pairs with [PS-4618](https://linear.app/) — Concorde gains a live watcher on `harmony-gang-config` so ops can tweak image repos, tolerations, env vars, etc. without a Concorde rollout.