### PR TITLE
feat(operator): settings ☢️

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.50.0
+version: 0.51.0
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/control-plane-role.yaml
+++ b/charts/adaptive/templates/control-plane-role.yaml
@@ -12,10 +12,10 @@ rules:
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["create", "get", "list", "delete"]
-  # core/v1 Pods — create bare GPU pods, watch gang pods, bulk-delete by label
+  # core/v1 Pods — create bare GPU pods, watch gang pods, annotate failed pods, bulk-delete by label
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["create", "get", "list", "watch", "deletecollection"]
+    verbs: ["create", "get", "list", "watch", "patch", "deletecollection"]
   # core/v1 Pods/log — fetch container logs
   - apiGroups: [""]
     resources: ["pods/log"]

--- a/charts/adaptive/templates/control-plane-role.yaml
+++ b/charts/adaptive/templates/control-plane-role.yaml
@@ -36,6 +36,12 @@ rules:
   - apiGroups: ["scheduling.run.ai"]
     resources: ["podgroups"]
     verbs: ["create", "get", "list", "watch", "delete"]
+  # policy/v1 PodDisruptionBudgets — per-job PDBs (maxUnavailable=0) created
+  # alongside the gang spawn and removed on cleanup. Block consolidator /
+  # descheduler / drain from evicting recipe-runner and harmony pods mid-job.
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["create", "get", "delete"]
   # coordination.k8s.io/v1 Leases — leader election for gang watchdog
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]

--- a/charts/adaptive/templates/operator-gang-config-confmap.yaml
+++ b/charts/adaptive/templates/operator-gang-config-confmap.yaml
@@ -54,6 +54,9 @@ data:
   {{- if .Values.adaptiveOperator.harmonyTolerations }}
   HARMONY_TOLERATIONS: {{ .Values.adaptiveOperator.harmonyTolerations | toJson | quote }}
   {{- end }}
+  {{- if .Values.adaptiveOperator.harmonyDshmSize }}
+  HARMONY_DSHM_SIZE: {{ .Values.adaptiveOperator.harmonyDshmSize | quote }}
+  {{- end }}
   {{- with (first .Values.imagePullSecrets) }}
   IMAGE_PULL_SECRET: {{ .name | quote }}
   {{- end }}

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -330,6 +330,13 @@ adaptiveOperator:
   #     operator: Exists
   #     effect: NoSchedule
   harmonyTolerations: []
+  # `sizeLimit` for the `/dev/shm` tmpfs (emptyDir, medium=Memory) mounted into
+  # harmony gang pods and inference replicas. NCCL inter-process rings and
+  # large tensor IPC live here, so the default is generous; tune down on small
+  # clusters or up for very large multi-GPU jobs. The tmpfs counts against the
+  # pod's MEMORY_LIMITS — bumping this requires headroom in adaptiveOperator.resources.limits.memory.
+  # Leave empty ("") to fall back to the operator's built-in default (32Gi).
+  harmonyDshmSize: "32Gi"
 
 controlPlane:
   sharedDirType: s3

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -334,8 +334,11 @@ adaptiveOperator:
   # harmony gang pods and inference replicas. NCCL inter-process rings and
   # large tensor IPC live here, so the default is generous; tune down on small
   # clusters or up for very large multi-GPU jobs. The tmpfs counts against the
-  # pod's MEMORY_LIMITS — bumping this requires headroom in adaptiveOperator.resources.limits.memory.
-  # Leave empty ("") to fall back to the operator's built-in default (32Gi).
+  # pod's total memory limit. `adaptiveOperator.resources.limits.memory` is a
+  # per-GPU limit, and the operator multiplies it by the pod's GPU count to
+  # determine the total pod memory limit, so bumping this requires headroom in
+  # that total computed limit. Leave empty ("") to fall back to the operator's
+  # built-in default (32Gi).
   harmonyDshmSize: "32Gi"
 
 controlPlane:


### PR DESCRIPTION
## Summary

Adds `adaptiveOperator.harmonyDshmSize` so chart consumers can tune the harmony pod `/dev/shm` (tmpfs emptyDir) without forking the chart. Surfaces the new `HARMONY_DSHM_SIZE` key just landed in the operator (see adaptive-ml/adaptive#4855).

- Default `"32Gi"` — matches the operator's built-in default and sizes generously for NCCL inter-process shared-memory rings on multi-GPU jobs.
- Setting `harmonyDshmSize: ""` omits the key, letting the operator's default apply.
- Chart bumped to **0.51.0**.

The tmpfs counts against the pod's memory limit, so operators bumping `harmonyDshmSize` need matching headroom in `adaptiveOperator.resources.limits.memory`.

**Missing RBAC permissions**: preventing operator reconciliation loop working 100% correctly

## Test plan

- [x] `helm lint charts/adaptive` passes
- [x] `helm template ... | grep HARMONY_DSHM_SIZE` shows `"32Gi"` by default
- [x] `--set adaptiveOperator.harmonyDshmSize=64Gi` overrides to `"64Gi"`
- [x] `--set adaptiveOperator.harmonyDshmSize=` omits the key entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)