### PR TITLE
fix(rbac): grant control-plane delete verb on pods

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.52.0
+version: 0.52.1
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/control-plane-role.yaml
+++ b/charts/adaptive/templates/control-plane-role.yaml
@@ -12,10 +12,11 @@ rules:
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["create", "get", "list", "delete"]
-  # core/v1 Pods — create bare GPU pods, watch gang pods, annotate failed pods, bulk-delete by label
+  # core/v1 Pods — create bare GPU pods, watch gang pods, annotate failed pods,
+  # delete individual Pending pods (gang cleanup path), bulk-delete by label
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["create", "get", "list", "watch", "patch", "deletecollection"]
+    verbs: ["create", "get", "list", "watch", "patch", "delete", "deletecollection"]
   # core/v1 Pods/log — fetch container logs
   - apiGroups: [""]
     resources: ["pods/log"]


### PR DESCRIPTION
## Summary

- Adds the missing `delete` verb on `pods` to the control-plane Role. The existing rule had `deletecollection` (delete many by label) but not `delete` (single resource by name) — Kubernetes RBAC treats these as distinct verbs.
- Bumps chart version to `0.52.1`.

## Why

Mangrove's gang-cleanup path deletes individual Pending harmony pods (being in timeout) by name via `api.delete(pod_name, …)` (see `mangrove/libs/k8s-operator/src/adapters/k8s/runtime_ops.rs` → `delete_pending_pod`). Without the `delete` verb the API server returns 403 and the bare pods become permanent orphans (no owner reference → no GC).

Observed in `fessenheim` after a recipe-runner SIGKILL triggered the gang teardown:

```
WARN failed to delete pending harmony pod
  pod=gang-019e658f-…-harmony-0
  error=ApiError: pods "gang-019e658f-…-harmony-0" is forbidden:
    User "system:serviceaccount:adaptive:serviceaccount.adaptive-ml.com"
    cannot delete resource "pods" in API group "" in the namespace "adaptive"
```

Result: 4 Pending pods stuck forever after a single failed gang teardown.