### PR TITLE
feat(operator): expose recipeRunnerNoSandbox gang-config knob (HAR-162)

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.52.1
+version: 0.52.2
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/operator-gang-config-confmap.yaml
+++ b/charts/adaptive/templates/operator-gang-config-confmap.yaml
@@ -26,6 +26,9 @@ data:
   HARMONY_IMAGE_REPO: {{ .Values.harmony.image.repository | quote }}
   RECIPE_RUNNER_IMAGE_REPO: {{ .Values.sandkasten.recipeRunner.repository | quote }}
   {{- end }}
+  # Bypass the recipe runner's in-process nsjail sandbox (operator default is
+  # "true" when unset). Set false to run recipes under nsjail.
+  RECIPE_RUNNER_NO_SANDBOX: {{ .Values.adaptiveOperator.recipeRunnerNoSandbox | quote }}
   # Harmony pod resources (CPU/memory requests and limits — applied per GPU,
   # multiplied by per-pod GPU count by the operator)
   CPU_REQUESTS: {{ .Values.adaptiveOperator.resources.requests.cpu | quote }}

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -311,6 +311,12 @@ adaptiveOperator:
   # Extra environment variables for recipe-runner pods (key-value map)
   # These are merged into RECIPE_RUNNER_ENV_VARS and override built-in values.
   extraRecipeRunnerEnvVars: {}
+  # Bypass the recipe runner's in-process nsjail sandbox. Default "true": the
+  # pod is already cluster-isolated, so the runner just execs python. Set
+  # "false" to run recipes under nsjail — the operator then runs the
+  # recipe-runner pod as root with the sandbox capability set + AppArmor
+  # unconfined so nsjail can create namespaces.
+  recipeRunnerNoSandbox: true
   # Secret env vars injected into harmony pods via valueFrom.secretKeyRef
   # List of {env_var, secret_name, secret_key} objects.
   # Example:


### PR DESCRIPTION
Expose `adaptiveOperator.recipeRunnerNoSandbox` (default `true`, preserving current behavior) and emit it as `RECIPE_RUNNER_NO_SANDBOX` in the `harmony-gang-config` ConfigMap.

Without this, helm-deployed environments fall back to the operator code default and there is no way to enable the recipe-runner nsjail sandbox without a code change. Setting `recipeRunnerNoSandbox: false` opts a deployment into nsjail; the operator then runs the recipe-runner pod as root with the sandbox cap set + AppArmor unconfined.

Needed to enable nsjail on test5 and preview. Companion change in `adaptive` flips the local kind gang config.

Linear: HAR-162

## Test plan
- [x] `helm template` renders `"true"` by default and `"false"` with `--set adaptiveOperator.recipeRunnerNoSandbox=false`
- [x] `helm lint`, `ct lint`, and `kubeconform` (31/31 valid) pass
- [x] Chart version bumped 0.52.1 to 0.52.2
- [ ] Deploy to test5 / preview and confirm recipe runners work under nsjail