### PR TITLE
feat(recipe-runner): pod-only isolation — seccomp DaemonSet + flag (HAR-162 #2)

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -327,3 +327,35 @@ jobs:
             helm template "$chart_name" "$chart" | kubeconform -strict -schema-location default -summary
             echo "::endgroup::"
           done
+
+  seccomp-test:
+    # Recipe-runner seccomp profile seam (HAR-162). Stands up a default-CNI kind
+    # cluster, installs the seccomp DaemonSet, and asserts a pod mimicking the
+    # operator-rendered Localhost securityContext actually starts on the node.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.17.0
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.12.0
+        with:
+          cluster_name: seccomp-test
+
+      - name: Wait for nodes ready
+        run: kubectl wait --for=condition=Ready node --all --timeout=300s
+
+      - name: Run seccomp profile assertions
+        run: ./scripts/test-recipe-runner-seccomp.sh
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods -A -o wide || true
+          kubectl describe pods -n seccomp-test || true
+          kubectl logs -n seccomp-test -l app.kubernetes.io/component=recipe-runner-seccomp --tail=200 || true

--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.53.5
+version: 0.53.6
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/operator-gang-config-confmap.yaml
+++ b/charts/adaptive/templates/operator-gang-config-confmap.yaml
@@ -38,6 +38,13 @@ data:
   # Bypass the recipe runner's in-process nsjail sandbox (operator default is
   # "true" when unset). Set false to run recipes under nsjail.
   RECIPE_RUNNER_NO_SANDBOX: {{ .Values.adaptiveOperator.recipeRunnerNoSandbox | quote }}
+  # Recipe-runner pod-only isolation (HAR-162); off by default.
+  RECIPE_RUNNER_POD_ISOLATION: {{ .Values.recipeRunner.podIsolation.enabled | quote }}
+  {{- if .Values.recipeRunner.seccompProfile.enabled }}
+  # Emitted only when the DaemonSet ships the profile, else the pod would fail
+  # to start referencing a localhostProfile absent from the node.
+  RECIPE_RUNNER_SECCOMP_PROFILE: {{ .Values.recipeRunner.seccompProfile.name | quote }}
+  {{- end }}
   # Harmony pod resources (CPU/memory requests and limits — applied per GPU,
   # multiplied by per-pod GPU count by the operator)
   CPU_REQUESTS: {{ .Values.adaptiveOperator.resources.requests.cpu | quote }}

--- a/charts/adaptive/templates/recipe-runner-seccomp-daemonset.yaml
+++ b/charts/adaptive/templates/recipe-runner-seccomp-daemonset.yaml
@@ -1,0 +1,161 @@
+{{- if .Values.recipeRunner.seccompProfile.enabled }}
+{{- $name := .Values.recipeRunner.seccompProfile.name -}}
+{{- $root := trimSuffix "/" .Values.recipeRunner.seccompProfile.kubeletSeccompRoot -}}
+{{- $dest := printf "%s/%s" $root $name -}}
+{{- $fullname := printf "%s-seccomp" (include "adaptive.recipeRunner.fullname" .) -}}
+# Custom Localhost seccomp profile for recipe-runner pods (HAR-162 pod-only
+# isolation). The profile is a faithful port of libs/code-sandbox/policy.kafel
+# (the policy nsjail enforces today): default ALLOW with the full SIGSYS/KILL
+# syscall list plus the socket() address-family allowlist. It is default-ALLOW
+# by design, layered on the pod's drop-ALL-caps + runAsNonRoot, exactly like
+# kafel runs on top of nsjail's namespace + capability stripping. policy.kafel
+# is the source of truth; keep this JSON in sync when that file changes.
+# The DaemonSet writes it to the kubelet seccomp root on every node so the
+# operator can reference it via securityContext.seccompProfile.localhostProfile.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adaptive.labels" . | nindent 4 }}
+    {{- include "adaptive.sharedSelectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: recipe-runner-seccomp
+data:
+  {{ base $name }}: |
+    {
+      "defaultAction": "SCMP_ACT_ALLOW",
+      "architectures": ["SCMP_ARCH_X86_64", "SCMP_ARCH_AARCH64"],
+      "syscalls": [
+        {
+          "action": "SCMP_ACT_KILL_PROCESS",
+          "names": [
+            "reboot", "settimeofday", "adjtimex", "clock_settime", "clock_adjtime",
+            "swapon", "swapoff", "acct", "quotactl",
+            "init_module", "finit_module", "delete_module",
+            "create_module", "query_module", "get_kernel_syms",
+            "kexec_load", "kexec_file_load",
+            "mount", "umount2", "pivot_root", "chroot",
+            "move_mount", "open_tree", "fsopen", "fsconfig", "fsmount", "mount_setattr",
+            "unshare", "setns",
+            "name_to_handle_at", "open_by_handle_at",
+            "ptrace", "process_vm_readv", "process_vm_writev",
+            "pidfd_open", "pidfd_getfd", "pidfd_send_signal",
+            "io_uring_setup", "io_uring_register", "io_uring_enter",
+            "userfaultfd",
+            "perf_event_open", "bpf", "add_key", "request_key", "keyctl",
+            "vmsplice", "modify_ldt", "personality", "uselib",
+            "iopl", "ioperm", "lookup_dcookie", "nfsservctl", "capset"
+          ]
+        },
+        {
+          "comment": "socket() address-family allowlist: allow only AF_UNIX(1), AF_INET(2), AF_INET6(10), AF_NETLINK(16); ERRNO(97 EAFNOSUPPORT) everything else (AF_UNSPEC, AF_PACKET, AF_VSOCK, AF_ALG, ...). Encoded as the complement of the allowed set since OCI seccomp cannot express not-in-set in one rule.",
+          "action": "SCMP_ACT_ERRNO",
+          "errnoRet": 97,
+          "names": ["socket"],
+          "args": [{ "index": 0, "value": 0, "op": "SCMP_CMP_EQ" }]
+        },
+        {
+          "action": "SCMP_ACT_ERRNO",
+          "errnoRet": 97,
+          "names": ["socket"],
+          "args": [
+            { "index": 0, "value": 3, "op": "SCMP_CMP_GE" },
+            { "index": 0, "value": 9, "op": "SCMP_CMP_LE" }
+          ]
+        },
+        {
+          "action": "SCMP_ACT_ERRNO",
+          "errnoRet": 97,
+          "names": ["socket"],
+          "args": [
+            { "index": 0, "value": 11, "op": "SCMP_CMP_GE" },
+            { "index": 0, "value": 15, "op": "SCMP_CMP_LE" }
+          ]
+        },
+        {
+          "action": "SCMP_ACT_ERRNO",
+          "errnoRet": 97,
+          "names": ["socket"],
+          "args": [{ "index": 0, "value": 17, "op": "SCMP_CMP_GE" }]
+        }
+      ]
+    }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adaptive.labels" . | nindent 4 }}
+    {{- include "adaptive.sharedSelectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: recipe-runner-seccomp
+spec:
+  selector:
+    matchLabels:
+      {{- include "adaptive.sharedSelectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: recipe-runner-seccomp
+  template:
+    metadata:
+      labels:
+        {{- include "adaptive.labels" . | nindent 8 }}
+        {{- include "adaptive.sharedSelectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: recipe-runner-seccomp
+    spec:
+      # Installer never calls the API server; drop the SA token.
+      automountServiceAccountToken: false
+      {{- with .Values.recipeRunner.seccompProfile.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # Root is needed to write the root-owned kubelet seccomp dir on the host;
+      # everything else is locked down (no privileged, no privesc, drop ALL).
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: installer
+          image: {{ .Values.recipeRunner.seccompProfile.image | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              mkdir -p "$(dirname "$DEST")"
+              cp "/profile/{{ base $name }}" "$DEST"
+              echo "installed recipe-runner seccomp profile at $DEST"
+              exec sleep infinity
+          env:
+            - name: DEST
+              value: {{ $dest | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            privileged: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.recipeRunner.seccompProfile.resources | nindent 12 }}
+          volumeMounts:
+            - name: profile
+              mountPath: /profile
+              readOnly: true
+            - name: seccomp-root
+              mountPath: {{ $root | quote }}
+      volumes:
+        - name: profile
+          configMap:
+            name: {{ $fullname }}
+        - name: seccomp-root
+          hostPath:
+            path: {{ $root | quote }}
+            type: DirectoryOrCreate
+{{- end }}

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -1288,12 +1288,13 @@ extraObjects: []
 #     data:
 #       password: {{ "secret" | b64enc | quote }}
 
-# ── Recipe-runner egress NetworkPolicy (HAR-162 #1) ────────────────────────
-# Egress policy for the per-job recipe-runner pods the operator spawns (they
-# carry operator labels, not the chart selector labels). Gated behind the
-# top-level networkPolicies.enabled switch AND this flag. Off by default;
-# requires a CNI that enforces NetworkPolicy.
+# ── Recipe-runner pod hardening (HAR-162) ──────────────────────────────────
+# Per-job recipe-runner pods the operator spawns (they carry operator labels,
+# not the chart selector labels). All knobs off by default.
 recipeRunner:
+  # Egress NetworkPolicy (HAR-162 #1). Gated behind the top-level
+  # networkPolicies.enabled switch AND this flag. Requires a CNI that enforces
+  # NetworkPolicy.
   networkPolicy:
     # On by default so the top-level networkPolicies.enabled master switch
     # gates this policy alongside the control-plane / harmony / sandkasten /
@@ -1311,3 +1312,27 @@ recipeRunner:
         protocol: TCP
     # Extra egress rules appended verbatim (e.g. external Redis/S3/MLflow CIDRs).
     additionalEgressRules: []
+  # Pod-only isolation (HAR-162 #2): drop the ServiceAccount token mount and
+  # assert hostNetwork/hostPID/hostIPC=false on recipe-runner pods (enforced by
+  # the operator via the gang ConfigMap).
+  podIsolation:
+    enabled: false
+  # Ship a custom Localhost seccomp profile to nodes via a DaemonSet and tell the
+  # operator to use it instead of RuntimeDefault. The profile here is a minimal
+  # baseline floor; the thorough syscall filter is applied in-process by the
+  # recipe-runner. Node-level change: the DaemonSet writes the profile JSON to
+  # the kubelet seccomp root on every node.
+  seccompProfile:
+    enabled: false
+    name: adaptive/recipe-runner.json
+    kubeletSeccompRoot: /var/lib/kubelet/seccomp
+    image: busybox:1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
+    tolerations:
+      - operator: Exists
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 50m
+        memory: 32Mi

--- a/scripts/test-recipe-runner-seccomp.sh
+++ b/scripts/test-recipe-runner-seccomp.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Verify the recipe-runner seccomp profile seam end-to-end on a real node.
+#
+# The operator (adaptive #5147) renders recipe-runner pods that reference a
+# Localhost seccomp profile (localhostProfile: adaptive/recipe-runner.json).
+# This chart ships that profile to every node's kubelet seccomp root via the
+# recipe-runner-seccomp DaemonSet. Neither repo's CI exercises the join: if the
+# DaemonSet does not place the file, the kubelet cannot resolve the Localhost
+# reference and the pod fails to start (CreateContainerError).
+#
+# This test closes that gap. It installs the DaemonSet, then applies a pod that
+# mimics the exact securityContext the operator renders (drop-ALL caps,
+# runAsNonRoot 1000, automount off, Localhost profile) and asserts:
+#   1. the DaemonSet installs the profile on the node,
+#   2. the mimic pod reaches Running (kubelet resolved the profile),
+#   3. the filter is actually loaded (Seccomp: 2 in /proc/self/status),
+#   4. a pod referencing a missing profile does NOT start (so #2 is meaningful).
+#
+# Assumes a running single-node cluster (kind) with kubectl + helm on PATH.
+# A NetworkPolicy-enforcing CNI is NOT required.
+
+set -euo pipefail
+
+CHART_DIR="${CHART_DIR:-./charts/adaptive}"
+RELEASE="${RELEASE:-adaptive-test}"
+NS="${NS:-seccomp-test}"
+VALUES_BASE="${VALUES_BASE:-.github/test-values-base.yaml}"
+# Mimic image: needs /proc/self/status + grep. Matches the netpol harness.
+PROBE_IMAGE="${PROBE_IMAGE:-busybox:1.36}"
+# Must match recipeRunner.seccompProfile.name in values.yaml.
+PROFILE="${PROFILE:-adaptive/recipe-runner.json}"
+START_TIMEOUT="${START_TIMEOUT:-120s}"
+# How long to wait before concluding the negative-control pod will not start.
+NEG_WAIT="${NEG_WAIT:-40}"
+
+SECCOMP_YAML="$(mktemp)"
+trap 'rm -f "$SECCOMP_YAML"' EXIT
+
+group()    { printf '\n::group::%s\n' "$*"; }
+endgroup() { printf '::endgroup::\n'; }
+fail()     { printf '\n✗ FAIL: %s\n' "$*" >&2; exit 1; }
+ok()       { printf '  ✓ %s\n' "$*"; }
+
+group "Render recipe-runner seccomp DaemonSet from chart"
+helm template "$RELEASE" "$CHART_DIR" \
+  -f "$VALUES_BASE" \
+  --namespace "$NS" \
+  --set recipeRunner.seccompProfile.enabled=true \
+  --show-only=templates/recipe-runner-seccomp-daemonset.yaml > "$SECCOMP_YAML"
+cat "$SECCOMP_YAML"
+endgroup
+
+group "Install DaemonSet + profile ConfigMap"
+kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -n "$NS" -f "$SECCOMP_YAML"
+DS="$(kubectl get ds -n "$NS" -l app.kubernetes.io/component=recipe-runner-seccomp \
+  -o jsonpath='{.items[0].metadata.name}')"
+[ -n "$DS" ] || fail "seccomp DaemonSet not created"
+kubectl rollout status -n "$NS" "ds/$DS" --timeout="$START_TIMEOUT" \
+  || fail "seccomp DaemonSet did not roll out"
+# The installer logs a confirmation line once the profile is copied to the node.
+# Logs can lag a moment behind the rollout, so poll rather than read once.
+installed=false
+for _ in $(seq 1 30); do
+  if kubectl logs -n "$NS" -l app.kubernetes.io/component=recipe-runner-seccomp --tail=5 \
+       2>/dev/null | grep -q "installed recipe-runner seccomp profile"; then
+    installed=true; break
+  fi
+  sleep 2
+done
+[ "$installed" = true ] || fail "installer did not report writing the profile"
+ok "DaemonSet installed the profile on the node"
+endgroup
+
+# Pod factory: the unprivileged recipe-runner securityContext, verbatim from the
+# operator's pod-isolation snapshot (adaptive #5147). Arg $2 is the profile to
+# reference, so the negative control can point at a missing one.
+mimic_pod() {
+  local name="$1" profile="$2"
+  cat <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $name
+  namespace: $NS
+  labels:
+    app.kubernetes.io/component: recipe-runner-gang
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    seccompProfile:
+      type: Localhost
+      localhostProfile: $profile
+  containers:
+    - name: main
+      image: $PROBE_IMAGE
+      command: ["sh", "-c", "grep Seccomp /proc/self/status; sleep 3600"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: false
+        capabilities:
+          drop: [ALL]
+        seccompProfile:
+          type: Localhost
+          localhostProfile: $profile
+EOF
+}
+
+group "Recipe-runner mimic pod starts with the Localhost profile"
+mimic_pod recipe-runner-mimic "$PROFILE" | kubectl apply -f -
+kubectl wait --for=condition=Ready pod/recipe-runner-mimic -n "$NS" \
+  --timeout="$START_TIMEOUT" \
+  || { kubectl describe pod/recipe-runner-mimic -n "$NS" || true
+       fail "mimic pod did not start (kubelet could not resolve the Localhost profile?)"; }
+ok "pod reached Running with seccompProfile=Localhost:$PROFILE"
+
+# Seccomp: 2 == SECCOMP_MODE_FILTER -> a BPF filter is loaded for the process.
+SECCOMP_MODE="$(kubectl logs -n "$NS" recipe-runner-mimic | awk '/Seccomp:/{print $2}')"
+[ "$SECCOMP_MODE" = "2" ] \
+  || fail "expected Seccomp mode 2 (filter), got '${SECCOMP_MODE:-<none>}'"
+ok "filter is loaded in the container (Seccomp: 2)"
+endgroup
+
+group "Negative control: missing profile must NOT start"
+mimic_pod recipe-runner-missing "adaptive/does-not-exist.json" | kubectl apply -f -
+# The kubelet rejects container creation and keeps retrying; the pod never goes
+# Ready. Give it a window, then assert it is still not Running.
+if kubectl wait --for=condition=Ready pod/recipe-runner-missing -n "$NS" \
+     --timeout="${NEG_WAIT}s" 2>/dev/null; then
+  fail "pod with a missing Localhost profile unexpectedly started"
+fi
+PHASE="$(kubectl get pod/recipe-runner-missing -n "$NS" -o jsonpath='{.status.phase}')"
+[ "$PHASE" != "Running" ] \
+  || fail "pod with a missing Localhost profile is Running"
+ok "pod with a missing profile correctly failed to start (phase=$PHASE)"
+kubectl describe pod/recipe-runner-missing -n "$NS" 2>/dev/null \
+  | grep -iE 'seccomp|cannot find|CreateContainerError' | head -3 || true
+endgroup
+
+printf '\n✓ PASS: recipe-runner seccomp profile seam verified end-to-end\n'


### PR DESCRIPTION
Helm half of recipe-runner pod-only isolation. **Slimmed**: the NetworkPolicy was split into its own PR (#154); this is now just the pod-hardening flag + the seccomp profile DaemonSet. Rebuilt on current main (the old branch was stale).

## What
- `recipeRunner.podIsolation` + `recipeRunner.seccompProfile` values (off by default).
- Gang ConfigMap emits `RECIPE_RUNNER_POD_ISOLATION` + `RECIPE_RUNNER_SECCOMP_PROFILE` (consumed by the operator — adaptive #5069 / the combined PR).
- `recipe-runner-seccomp-daemonset.yaml`: ships a Localhost seccomp profile to the kubelet seccomp root on every node. This is a **minimal baseline floor**; the thorough kafel syscall filter is applied in-process by the recipe-runner (combined PR).

## Non-breaking
Both knobs off by default; default render is unchanged (0 seccomp artifacts when off). `helm lint` + `ct lint` clean (v0.52.9).

Pairs with: #154 (NetworkPolicy) and the adaptive combined operator+in-process-seccomp PR.