### PR TITLE
☢️ feat(operator): expose NUMA-aware CPU alignment config

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.52.1
+version: 0.52.2
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/operator-gang-config-confmap.yaml
+++ b/charts/adaptive/templates/operator-gang-config-confmap.yaml
@@ -11,6 +11,15 @@
 {{- fail (printf "adaptiveOperator.efasPerNode must be > 0 when interconnect=\"efa\", got %v" .Values.adaptiveOperator.efasPerNode) -}}
 {{- end -}}
 {{- end -}}
+{{- /* ── NUMA-aware CPU alignment validation ───────────────────────────── */ -}}
+{{- if .Values.adaptiveOperator.numaEnabled -}}
+{{- if not (gt (int .Values.adaptiveOperator.numaNodesPerHost) 0) -}}
+{{- fail (printf "adaptiveOperator.numaNodesPerHost must be > 0 when numaEnabled=true, got %v" .Values.adaptiveOperator.numaNodesPerHost) -}}
+{{- end -}}
+{{- if not (gt (int .Values.adaptiveOperator.cpusPerNumaNode) 0) -}}
+{{- fail (printf "adaptiveOperator.cpusPerNumaNode must be > 0 when numaEnabled=true, got %v" .Values.adaptiveOperator.cpusPerNumaNode) -}}
+{{- end -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -38,6 +47,13 @@ data:
   HARMONY_INTERCONNECT: {{ .Values.adaptiveOperator.interconnect | quote }}
   {{- if eq .Values.adaptiveOperator.interconnect "efa" }}
   EFAS_PER_NODE: {{ .Values.adaptiveOperator.efasPerNode | quote }}
+  {{- end }}
+  # NUMA-aware CPU alignment: pin pods to NUMA domains so cores, memory, and
+  # GPUs share a socket. Topology keys emitted only when enabled.
+  NUMA_ENABLED: {{ .Values.adaptiveOperator.numaEnabled | quote }}
+  {{- if .Values.adaptiveOperator.numaEnabled }}
+  NUMA_NODES_PER_HOST: {{ .Values.adaptiveOperator.numaNodesPerHost | quote }}
+  CPUS_PER_NUMA_NODE: {{ .Values.adaptiveOperator.cpusPerNumaNode | quote }}
   {{- end }}
   {{- if .Values.adaptiveOperator.customLabels }}
   CUSTOM_LABELS: {{ .Values.adaptiveOperator.customLabels | toJson | quote }}

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -282,6 +282,20 @@ adaptiveOperator:
   # ceil(podGpus * efasPerNode / gpusPerNode) per pod, so full-node pods get
   # the full count and remainder pods get a proportional share.
   efasPerNode: 0
+  # ── NUMA-aware CPU alignment ───────────────────────────────────────────
+  # Pin gang-spawned harmony pods to NUMA domains so CPU cores, memory, and
+  # the GPUs they drive sit on the same socket, avoiding cross-socket QPI/UPI
+  # traffic on multi-socket nodes. Disabled by default; when enabled, both
+  # numaNodesPerHost and cpusPerNumaNode are required.
+  #
+  # The gate. false/absent → NUMA alignment off (current behavior).
+  numaEnabled: false
+  # NUMA domains per node (e.g. 2 for a dual-socket host). Required when
+  # numaEnabled=true.
+  numaNodesPerHost: 0
+  # Allocatable whole cores per NUMA node (e.g. 96). On asymmetric nodes use
+  # the smaller socket's core count. Required when numaEnabled=true.
+  cpusPerNumaNode: 0
   # Extra Kubernetes extended resources to request per GPU on gang-spawned harmony pods
   # Used for device-plugin-managed resources beyond nvidia.com/gpu (which is set automatically).
   # Note: when interconnect is "efa" or "infiniband", the corresponding fabric resource


### PR DESCRIPTION
## What

Exposes NUMA-aware CPU alignment through the `harmony-gang-config` ConfigMap so the k8s-operator can pin gang-spawned harmony pods to NUMA domains. Aligning CPU cores, memory, and the GPUs they drive onto the same socket avoids cross-socket QPI/UPI traffic on multi-socket nodes.

Follows the same pattern as the gang bin-packing / inter-node fabric config (#145): `adaptiveOperator.*` values → validation + keys in `operator-gang-config-confmap.yaml`.

## New ConfigMap keys

| Key | Type | Default | Purpose |
|-----|------|---------|---------|
| `NUMA_ENABLED` | bool | `false` | The gate. Empty/absent → off. |
| `NUMA_NODES_PER_HOST` | int | `0` | NUMA domains per node (e.g. 2). Required when enabled. |
| `CPUS_PER_NUMA_NODE` | int | `0` | Allocatable whole cores per NUMA node (e.g. 96; use the smaller socket on asymmetric nodes). Required when enabled. |

Surfaced in `values.yaml` as `adaptiveOperator.numaEnabled` / `numaNodesPerHost` / `cpusPerNumaNode`.

`NUMA_ENABLED` is always emitted so the operator sees an explicit gate. `NUMA_NODES_PER_HOST` and `CPUS_PER_NUMA_NODE` are emitted only when `numaEnabled=true` (mirrors how `EFAS_PER_NODE` is gated on `interconnect=efa`).

## Validation

Template-time checks mirror the operator's runtime validation and fail fast with clear messages:
- `adaptiveOperator.numaNodesPerHost` must be > 0 when `numaEnabled=true`
- `adaptiveOperator.cpusPerNumaNode` must be > 0 when `numaEnabled=true`

## Behavior change

None by default — alignment is off and no topology keys are emitted, preserving current behavior. The `☢️` marker indicates this requires corresponding k8s-operator support to consume the new keys.