### PR TITLE
fix(rbac): control-plane: watch deployments + drop unused perms on jobs

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.52.6
+version: 0.52.7
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/control-plane-role.yaml
+++ b/charts/adaptive/templates/control-plane-role.yaml
@@ -29,10 +29,11 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
-  # apps/v1 Deployments — inference partition lifecycle (create, resize, annotate, delete)
+  # apps/v1 Deployments — inference partition lifecycle (create, resize, annotate,
+  # delete) plus watch for the real-time GPU Fleet View "Deploying" status
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["create", "get", "patch", "delete", "list", "deletecollection"]
+    verbs: ["create", "get", "list", "watch", "patch", "delete", "deletecollection"]
   # scheduling.run.ai/v2alpha2 PodGroups — gang job submission, phase watching, cleanup
   - apiGroups: ["scheduling.run.ai"]
     resources: ["podgroups"]

--- a/charts/adaptive/templates/control-plane-role.yaml
+++ b/charts/adaptive/templates/control-plane-role.yaml
@@ -8,10 +8,6 @@ metadata:
     {{- include "adaptive.labels" . | nindent 4 }}
     {{- include "adaptive.controlPlane.selectorLabels" . | nindent 4 }}
 rules:
-  # batch/v1 Jobs — full lifecycle (create, monitor, cleanup)
-  - apiGroups: ["batch"]
-    resources: ["jobs"]
-    verbs: ["create", "get", "list", "delete"]
   # core/v1 Pods — create bare GPU pods, watch gang pods, annotate failed pods,
   # delete individual Pending pods (gang cleanup path), bulk-delete by label
   - apiGroups: [""]


### PR DESCRIPTION
Two control-plane RBAC changes in `control-plane-role.yaml`.

Fix RBAC permissions

---

Chart version bumped `0.52.6 -> 0.52.7`.
