### PR TITLE
feat(recipe-runner): egress NetworkPolicy for gang recipe-runner pods (HAR-162)

### DIFF
--- a/.github/test-values-netpol.yaml
+++ b/.github/test-values-netpol.yaml
@@ -29,3 +29,9 @@ harmony:
 otelCollector:
   networkPolicy:
     enabled: true
+
+# Recipe-runner egress NetworkPolicy (HAR-162 #1).
+recipeRunner:
+  networkPolicy:
+    enabled: true
+    allowInternetEgress: true

--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.53.0
+version: 0.53.2
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/_helpers.tpl
+++ b/charts/adaptive/templates/_helpers.tpl
@@ -948,3 +948,7 @@ Usage:
       port: {{ .port }}
 {{- end }}
 {{- end }}
+
+{{- define "adaptive.recipeRunner.fullname" -}}
+{{- printf "%s-recipe-runner" (include "adaptive.fullname" .) | trunc 40 | trimSuffix "-" }}
+{{- end}}

--- a/charts/adaptive/templates/recipe-runner-networkpolicy.yaml
+++ b/charts/adaptive/templates/recipe-runner-networkpolicy.yaml
@@ -1,0 +1,81 @@
+{{- if and .Values.networkPolicies.enabled .Values.recipeRunner.networkPolicy.enabled }}
+# Egress NetworkPolicy for the per-job recipe-runner pods spawned by the
+# operator (HAR-162 #1). These carry operator labels (app.kubernetes.io/component:
+# recipe-runner-gang), NOT the chart's name/instance selector labels, so the
+# podSelector is hand-written. Selecting the pod with an Egress policy makes all
+# egress not listed below default-deny — that is the lockdown.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "adaptive.recipeRunner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adaptive.labels" . | nindent 4 }}
+    {{- include "adaptive.sharedSelectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: recipe-runner-gang
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: recipe-runner-gang
+      adaptive.ml/managed-by: control-plane
+  policyTypes:
+    - Egress
+  egress:
+    # Cluster DNS — needed for in-cluster Service names and external hostnames.
+    {{- include "adaptive.networkPolicy.dnsEgress" . | nindent 4 }}
+    # Harmony gang master — the runner's HARMONY_WS_ENDPOINT (ws://...:50053).
+    # The master pod is operator-created with component=harmony-gang.
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: harmony-gang
+      ports:
+        - protocol: TCP
+          port: 50053
+    # Control plane (Concorde) — recipes call it via ADAPTIVE_CONTROL_PLANE_URL.
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "adaptive.controlPlane.selectorLabels" . | nindent 14 }}
+    {{- if .Values.otelCollector.enabled }}
+    # OTel collector — the runner exports traces/metrics when enabled.
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "adaptive.otelCollector.selectorLabels" . | nindent 14 }}
+    {{- end }}
+    {{- if .Values.mlflow.enabled }}
+    # MLflow — recipes log experiments / metrics here.
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "adaptive.mlflow.selectorLabels" . | nindent 14 }}
+    {{- end }}
+    {{- if .Values.minio.enabled }}
+    # Internal MinIO — recipes read/write artifacts in the shared S3 bucket.
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "adaptive.minio.selectorLabels" . | nindent 14 }}
+    {{- end }}
+    {{- if .Values.s3proxy.enabled }}
+    # s3proxy — in-cluster S3 facade (Azure Blob, etc.) for recipe artifact I/O.
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "adaptive.s3proxy.selectorLabels" . | nindent 14 }}
+    {{- end }}
+    {{- if .Values.recipeRunner.networkPolicy.allowInternetEgress }}
+    # External egress on the listed ports (off by default; tighter than the
+    # sandkasten policy). Enable so recipes can `pip install` / pull datasets /
+    # weights. Port-restricted to avoid the EKS Auto Mode `except` cross-rule
+    # bleed; do NOT switch to a broad 0.0.0.0/0 + except shape.
+    {{- include "adaptive.networkPolicy.internetEgress"
+          (dict "ports" .Values.recipeRunner.networkPolicy.internetEgressPorts)
+        | nindent 4 }}
+    {{- end }}
+    {{- with .Values.recipeRunner.networkPolicy.additionalEgressRules }}
+    # Environment-specific allow rules (external Redis/S3/MLflow CIDRs, etc.).
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -1277,3 +1277,23 @@ extraObjects: []
 #       name: extra-secret
 #     data:
 #       password: {{ "secret" | b64enc | quote }}
+
+# ── Recipe-runner egress NetworkPolicy (HAR-162 #1) ────────────────────────
+# Egress policy for the per-job recipe-runner pods the operator spawns (they
+# carry operator labels, not the chart selector labels). Gated behind the
+# top-level networkPolicies.enabled switch AND this flag. Off by default;
+# requires a CNI that enforces NetworkPolicy.
+recipeRunner:
+  networkPolicy:
+    enabled: false
+    # Allow public-internet egress on internetEgressPorts so recipes can
+    # `pip install` / pull datasets / weights. Off by default (tighter than the
+    # sandkasten policy). Turn on or use additionalEgressRules as needed.
+    allowInternetEgress: false
+    internetEgressPorts:
+      - port: 443
+        protocol: TCP
+      - port: 80
+        protocol: TCP
+    # Extra egress rules appended verbatim (e.g. external Redis/S3/MLflow CIDRs).
+    additionalEgressRules: []

--- a/scripts/test-sandkasten-netpol.sh
+++ b/scripts/test-sandkasten-netpol.sh
@@ -33,6 +33,7 @@ POLICIES=(
   control-plane-networkpolicy.yaml
   harmony-networkpolicy.yaml
   otel-collector-networkpolicy.yaml
+  recipe-runner-networkpolicy.yaml
 )
 
 # Detect Cilium: include the chart's CiliumNetworkPolicy for cp -> apiserver
@@ -134,6 +135,31 @@ EOF
   make_pod redis-target         redis          8080
   make_pod mlflow-target        mlflow         8080
   make_pod other-target         unrelated      8080
+  # Recipe-runner pod-only isolation (HAR-162). One harmony-gang target listens
+  # on the allowed WS port (50053) and another on a non-allowed port (8080) so
+  # the deny assertion proves a policy drop, not a connection-refused. The probe
+  # carries BOTH operator labels the policy podSelector matches.
+  make_pod harmony-gang-target  harmony-gang   50053
+  make_pod harmony-gang-8080    harmony-gang   8080
+  cat <<EOF
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: recipe-runner-probe
+  namespace: $NS
+  labels:
+    app.kubernetes.io/name: adaptive
+    app.kubernetes.io/instance: $RELEASE
+    app.kubernetes.io/component: recipe-runner-gang
+    adaptive.ml/managed-by: control-plane
+spec:
+  restartPolicy: Never
+  containers:
+    - name: main
+      image: $PROBE_IMAGE
+      command: ["sleep", "3600"]
+EOF
 } | kubectl apply -f -
 
 kubectl wait --for=condition=Ready pod --all -n "$NS" --timeout=180s
@@ -151,6 +177,8 @@ PG_IP=$(get_ip postgres-target)
 REDIS_IP=$(get_ip redis-target)
 MLFLOW_IP=$(get_ip mlflow-target)
 OTHER_IP=$(get_ip other-target)
+HGANG_IP=$(get_ip harmony-gang-target)
+HGANG8080_IP=$(get_ip harmony-gang-8080)
 KUBE_API_IP=$(kubectl get svc -n default kubernetes -o jsonpath='{.spec.clusterIP}')
 
 # `nc -zv` returns 0 on connect, non-zero on refused/timeout. We wrap in
@@ -259,6 +287,30 @@ assert_from deny  otel-probe "redis"                "$REDIS_IP"           8080  
 assert_from deny  otel-probe "mlflow"               "$MLFLOW_IP"          8080  || failed=1
 assert_from deny  otel-probe "kubernetes API"       "$KUBE_API_IP"        443   || failed=1
 assert_from deny  otel-probe "unrelated"            "$OTHER_IP"           8080  || failed=1
+endgroup
+
+group "recipe-runner egress (harmony-gang WS, cp/otel/mlflow, DNS, internet)"
+# The runner's WS endpoint is the gang master on :50053.
+assert_from allow recipe-runner-probe "harmony-gang :50053" "$HGANG_IP"  50053 || failed=1
+assert_from allow recipe-runner-probe "control-plane"       "$CP_IP"     8080  || failed=1
+assert_from allow recipe-runner-probe "otel-collector"      "$OTEL_IP"   8080  || failed=1
+assert_from allow recipe-runner-probe "mlflow"              "$MLFLOW_IP" 8080  || failed=1
+assert_from allow recipe-runner-probe "internet (1.1.1.1)"  "1.1.1.1"    443   || failed=1
+printf '  [%-5s] %-28s %s ... ' "allow" "DNS lookup" "kubernetes.default"
+if kubectl exec -n "$NS" recipe-runner-probe -- timeout "$NC_TIMEOUT" \
+    nslookup kubernetes.default.svc.cluster.local >/dev/null 2>&1; then
+  printf 'ok\n'
+else
+  printf 'FAIL\n'; failed=1
+fi
+# Recipe runner has no redis egress (unlike sandkasten) and must not reach
+# the gang master on non-WS ports, postgres, the apiserver, or unrelated pods.
+assert_from deny  recipe-runner-probe "harmony-gang :8080" "$HGANG8080_IP" 8080 || failed=1
+assert_from deny  recipe-runner-probe "redis"              "$REDIS_IP"    8080 || failed=1
+assert_from deny  recipe-runner-probe "sandkasten"         "$SAND_IP"     8080 || failed=1
+assert_from deny  recipe-runner-probe "postgres"           "$PG_IP"       8080 || failed=1
+assert_from deny  recipe-runner-probe "kubernetes API"     "$KUBE_API_IP" 443  || failed=1
+assert_from deny  recipe-runner-probe "unrelated"          "$OTHER_IP"    8080 || failed=1
 endgroup
 
 if [[ $failed -ne 0 ]]; then


### PR DESCRIPTION
Splits the **recipe-runner NetworkPolicy** out of #151 into its own standalone PR (per review — #151 bundled netpol + seccomp + the pod-isolation flag).

## What
- `recipe-runner-networkpolicy.yaml`: egress NetworkPolicy selecting `app.kubernetes.io/component: recipe-runner-gang` pods (the operator-spawned per-job recipe runners, which carry operator labels rather than chart selector labels). Selecting them with an Egress policy makes all unlisted egress default-deny.
- `recipeRunner.networkPolicy` values (`enabled`, `allowInternetEgress`, `internetEgressPorts`, `additionalEgressRules`).
- `adaptive.recipeRunner.fullname` helper.

## Non-breaking
Gated behind `networkPolicies.enabled` **and** `recipeRunner.networkPolicy.enabled`, both off by default. Default render is unchanged (0 NetworkPolicy emitted when off).

## Tests
- `helm lint` + `ct lint` (v0.52.8) clean; off-by-default render emits nothing.
- Exercised by the existing `netpol-test` CI job (`test-sandkasten-netpol.sh`, updated here) across the CNI matrix.

Seccomp DaemonSet + pod-isolation flag remain in #151 (to be slimmed) and fold into the adaptive combined PR.