### PR TITLE
fix(rbac): control-plane batch/jobs permission (compute-pool discovery)

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.53.0
+version: 0.53.1
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/control-plane-role.yaml
+++ b/charts/adaptive/templates/control-plane-role.yaml
@@ -30,6 +30,12 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["create", "get", "list", "watch", "patch", "delete", "deletecollection"]
+  # batch/v1 Jobs — gang/recipe-runner job lifecycle + compute-pool/GPU-stats
+  # discovery (the concorde resolver and run-submission path list jobs). Without
+  # this, gang deployments' control-plane SA gets 403 listing jobs (no pools).
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "delete"]
   # scheduling.run.ai/v2alpha2 PodGroups — gang job submission, phase watching, cleanup
   - apiGroups: ["scheduling.run.ai"]
     resources: ["podgroups"]


### PR DESCRIPTION
## Problem
The control-plane Role grants `apps/deployments` + gang perms but **not `batch/jobs`**. The concorde compute-pool/GPU-stats resolver and the run-submission path list `batch/jobs` to discover gangs, so any gang/job deployment's control-plane SA hits a 403 listing jobs → no compute pools + "Failed to submit run".

## Fix
Add `batch/jobs: [create, get, list, delete]` to the control-plane namespaced Role.

## Evidence
Surfaced on adaptive-fessenheim after it moved onto the main-based chart (it lost compute pools + couldn't submit runs). Restoring this rule fixed it — verified a recipe completed end-to-end.

Linear: HAR-167