### PR TITLE
fix(chart): namespace-key control-plane cluster-scoped ClusterRole/Binding (HAR-165)

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.53.2
+version: 0.53.3
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/_helpers.tpl
+++ b/charts/adaptive/templates/_helpers.tpl
@@ -247,12 +247,16 @@ Service account fullnames for each component
 {{- printf "%s-rolebinding" (include "adaptive.controlPlane.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
+{{- /* Cluster-scoped objects are global, so the name must be unique per install
+   within a cluster. Concurrent installs (e.g. preview envs) share a release
+   name, so key on .Release.Namespace to avoid colliding on one shared
+   ClusterRole/ClusterRoleBinding (HAR-165). */ -}}
 {{- define "adaptive.controlPlane.clusterRole.fullname" -}}
-{{- printf "%s-clusterrole" (include "adaptive.controlPlane.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-clusterrole" (include "adaptive.controlPlane.fullname" .) .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
 {{- define "adaptive.controlPlane.clusterRoleBinding.fullname" -}}
-{{- printf "%s-clusterrolebinding" (include "adaptive.controlPlane.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-clusterrolebinding" (include "adaptive.controlPlane.fullname" .) .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
 # MLFlow selector labels


### PR DESCRIPTION
Fixes HAR-165.

## Problem

The **cluster-scoped** `ClusterRole`/`ClusterRoleBinding` in `control-plane-role.yaml` were named via `adaptive.controlPlane.fullname` (release-name based). All preview envs deploy with `releaseName: adaptive`, so every concurrent install in one cluster rendered the same cluster-scoped names and collided on a single shared `ClusterRoleBinding` (last writer wins the subject SA). The env that did not last-write got `queues.scheduling.run.ai is forbidden ... at the cluster scope (403)` on the operator gang path. Latent until the fessenheim gang path (KAI queue creation) runs in >1 preview env per cluster, which the recent nsjail rollout to preview surfaced.

## Fix

Fold `.Release.Namespace` into the two cluster-scoped name helpers, matching how the namespaced `Role`/`RoleBinding` are already keyed. Verified via `helm template` across namespaces:

- `adaptive-preview-pr-5156` -> `adaptive-controlplane-adaptive-preview-pr-5156-clusterrole`
- `adaptive-preview-pr-4975` -> `adaptive-controlplane-adaptive-preview-pr-4975-clusterrole`
- each `ClusterRoleBinding` roleRef points to its own namespace ClusterRole.

Chart version bumped 0.53.2 -> 0.53.3.

## Migration note

On upgrade, ArgoCD creates the new namespace-keyed ClusterRole/Binding and prunes the old shared `adaptive-controlplane-clusterrole(binding)`. Single-install clusters (fessenheim) just see a one-time rename; multi-tenant preview clusters stop sharing.