### PR TITLE
Opt-in crash reporting flag for harmony (HAR-170)

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.53.3
+version: 0.53.4
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/harmony-statefulset.yaml
+++ b/charts/adaptive/templates/harmony-statefulset.yaml
@@ -162,6 +162,14 @@ spec:
               value: "http://{{ include "adaptive.harmony.computePool.fullname" (dict "root" $root "pool" $pool) }}-0.{{ include "adaptive.harmony.computePool.headlessService.fullname" (dict "root" $root "pool" $pool) }}:{{ $ports.http.containerPort }}"
             - name: ADAPTIVE_LOGGING_LEVEL
               value: info
+            {{- if $root.Values.harmony.crashReporting.enabled }}
+            - name: CRASH_REPORTING_ENABLED
+              value: "true"
+            {{- with $root.Values.harmony.crashReporting.s3Url }}
+            - name: CRASH_DUMPS_S3_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
             {{- if eq $root.Values.controlPlane.sharedDirType "s3" }}
             - name: HARMONY_SETTING_WORKING_DIR
               value: "/opt/adaptive/working_dir"

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -169,6 +169,17 @@ harmony:
     type: emptyDir
     # hostPath: /opt/adaptive/cloud_cache  # Required when type is "hostPath"
 
+  # Out-of-process minidump crash reporting for harmony. Off by default; opt in
+  # per deployment. When enabled, fatal signals (SIGSEGV, SIGABRT, ...) produce
+  # a minidump that is logged and, if s3Url is set, uploaded.
+  crashReporting:
+    enabled: false
+    # Optional s3://bucket/prefix for dump uploads. Reuses the pod's existing S3
+    # credentials (secrets.s3Creds), so point it at a bucket those creds can
+    # write (e.g. the model-registry bucket). Empty = node-local dumps only.
+    # On HIPAA environments this must be an in-account bucket, never a SaaS one.
+    s3Url: ""
+
   # Size of /dev/shm (shared memory) volume for NCCL and other IPC
   # This should not be modified under normal circumstances
   shmSize: 32Gi

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -177,7 +177,6 @@ harmony:
     # Optional s3://bucket/prefix for dump uploads. Reuses the pod's existing S3
     # credentials (secrets.s3Creds), so point it at a bucket those creds can
     # write (e.g. the model-registry bucket). Empty = node-local dumps only.
-    # On HIPAA environments this must be an in-account bucket, never a SaaS one.
     s3Url: ""
 
   # Size of /dev/shm (shared memory) volume for NCCL and other IPC


### PR DESCRIPTION
Linear: HAR-170
Pairs with: adaptive#5222 (the crash-reporting implementation)

Adds an explicit, off-by-default feature flag so harmony only captures crash minidumps where it's deliberately turned on.

## Changes

- `harmony.crashReporting.enabled` (default `false`) and `harmony.crashReporting.s3Url` (default `""`) in values.
- When enabled, the harmony StatefulSet gets `CRASH_REPORTING_ENABLED=true`; when `s3Url` is also set, it gets `CRASH_DUMPS_S3_URL`. Disabled renders no crash env at all.
- Chart bumped 0.53.3 -> 0.53.4.

The Rust side (`crash_reporting::init`) is a no-op unless `CRASH_REPORTING_ENABLED` is set, so the chart default keeps the feature entirely off.

## Reusing the existing S3 bucket

`s3Url` uploads use the pod's existing `secrets.s3Creds` (the model-registry S3 user), which already has bucket-wide `s3:PutObject`. Point it at a sibling prefix on the model-registry bucket (e.g. `s3://<reg-bucket>/crash-dumps`) and no new IAM or secret is needed. On HIPAA envs (gator) this must be the in-account bucket, never a SaaS crash service; minidumps contain raw stack memory.

## Test plan

- [x] `helm template` with flag off: no `CRASH_*` env rendered.
- [x] flag on, no s3Url: only `CRASH_REPORTING_ENABLED`.
- [x] flag on + s3Url: both env vars, correct values.
- [x] `ct lint` passes (version bump recognized), `kubeconform -strict`: 30/30 valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)