### PR TITLE
feat(netpol): otel OTLP export egress + recipe-runner policy on by default (HAR-162)

### DIFF
--- a/.github/test-values-netpol.yaml
+++ b/.github/test-values-netpol.yaml
@@ -30,8 +30,9 @@ otelCollector:
   networkPolicy:
     enabled: true
 
-# Recipe-runner egress NetworkPolicy (HAR-162 #1).
+# Recipe-runner egress NetworkPolicy (HAR-162 #1). enabled is intentionally
+# left unset to exercise the chart default (true since 0.53.4): the master
+# switch alone must render this policy alongside the other four.
 recipeRunner:
   networkPolicy:
-    enabled: true
     allowInternetEgress: true

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,9 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Upgrade Guide](#upgrade-guide)
+  - [0.53.x to 0.53.4](#053x-to-0534)
+    - [otel-collector NetworkPolicy now allows OTLP export (:4317 / :4318)](#otel-collector-networkpolicy-now-allows-otlp-export-4317--4318)
+    - [recipe-runner NetworkPolicy now on by default under the master switch](#recipe-runner-networkpolicy-now-on-by-default-under-the-master-switch)
   - [0.52.x to 0.52.5](#052x-to-0525)
     - [NetworkPolicies are now opt-in behind `networkPolicies.enabled`](#networkpolicies-are-now-opt-in-behind-networkpoliciesenabled)
     - [New values added](#new-values-added)
@@ -25,6 +28,16 @@
 # Upgrade Guide
 
 This document describes breaking changes between Helm chart versions and how to migrate your configuration.
+
+## 0.53.x to 0.53.4
+
+### otel-collector NetworkPolicy now allows OTLP export (:4317 / :4318)
+
+The otel-collector NetworkPolicy now always permits OTLP egress on TCP 4317 (gRPC) and 4318 (HTTP), so the collector can ship telemetry to an in-cluster collector in another namespace (e.g. `otel-collector.otel`, `datadog`) or a remote backend without extending `internetEgressPorts`. No action required.
+
+### recipe-runner NetworkPolicy now on by default under the master switch
+
+`recipeRunner.networkPolicy.enabled` now defaults to `true`, so a single `networkPolicies.enabled: true` renders the recipe-runner egress policy alongside the control-plane / harmony / sandkasten / otel-collector ones. It still renders only when `networkPolicies.enabled` is true and remains individually disableable. Its public-internet egress stays off by default (`allowInternetEgress: false`); enable it per-environment for recipe workloads that need `pip install` / dataset pulls.
 
 ## 0.52.x to 0.52.5
 

--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.53.3
+version: 0.53.4
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/otel-collector-networkpolicy.yaml
+++ b/charts/adaptive/templates/otel-collector-networkpolicy.yaml
@@ -45,6 +45,14 @@ spec:
         - protocol: TCP
           port: 4318
     {{- end }}
+    # OTLP export. Shipping telemetry is the collector's purpose, so allow
+    # OTLP gRPC :4317 and HTTP :4318 egress unconditionally. The backend may
+    # be an in-cluster collector in another namespace (e.g. otel-collector.otel,
+    # datadog) or a remote SaaS. Port-restricted 0.0.0.0/0 (no `except`, to
+    # avoid the EKS Auto Mode cross-rule bleed).
+    {{- include "adaptive.networkPolicy.internetEgress"
+          (dict "ports" (list (dict "port" 4317 "protocol" "TCP") (dict "port" 4318 "protocol" "TCP")))
+        | nindent 4 }}
     {{- if $hasRestrictive }}
     # restrictiveEgressRules is set — the user is taking control of the
     # otel-collector's external egress. The default permissive internet rule

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -1285,10 +1285,14 @@ extraObjects: []
 # requires a CNI that enforces NetworkPolicy.
 recipeRunner:
   networkPolicy:
-    enabled: false
+    # On by default so the top-level networkPolicies.enabled master switch
+    # gates this policy alongside the control-plane / harmony / sandkasten /
+    # otel-collector ones: one switch renders all chart NetworkPolicies. Still
+    # individually disableable here.
+    enabled: true
     # Allow public-internet egress on internetEgressPorts so recipes can
     # `pip install` / pull datasets / weights. Off by default (tighter than the
-    # sandkasten policy). Turn on or use additionalEgressRules as needed.
+    # sandkasten policy); enable per-env for recipe workloads that need it.
     allowInternetEgress: false
     internetEgressPorts:
       - port: 443

--- a/scripts/test-sandkasten-netpol.sh
+++ b/scripts/test-sandkasten-netpol.sh
@@ -135,6 +135,9 @@ EOF
   make_pod redis-target         redis          8080
   make_pod mlflow-target        mlflow         8080
   make_pod other-target         unrelated      8080
+  # OTLP backend on :4317 to prove the otel-collector's OTLP export egress
+  # (always-on 4317/4318 to any destination) renders and is allowed.
+  make_pod otlp-target          otlp-backend   4317
   # Recipe-runner pod-only isolation (HAR-162). One harmony-gang target listens
   # on the allowed WS port (50053) and another on a non-allowed port (8080) so
   # the deny assertion proves a policy drop, not a connection-refused. The probe
@@ -177,6 +180,7 @@ PG_IP=$(get_ip postgres-target)
 REDIS_IP=$(get_ip redis-target)
 MLFLOW_IP=$(get_ip mlflow-target)
 OTHER_IP=$(get_ip other-target)
+OTLP_IP=$(get_ip otlp-target)
 HGANG_IP=$(get_ip harmony-gang-target)
 HGANG8080_IP=$(get_ip harmony-gang-8080)
 KUBE_API_IP=$(kubectl get svc -n default kubernetes -o jsonpath='{.spec.clusterIP}')
@@ -278,6 +282,9 @@ group "otel-collector egress (scrape ports, DNS, internet)"
 assert_from allow otel-probe "control-plane :9009"  "$CP_METRICS_IP"      9009  || failed=1
 assert_from allow otel-probe "harmony :50053"       "$HARMONY_METRICS_IP" 50053 || failed=1
 assert_from allow otel-probe "internet (1.1.1.1)"   "1.1.1.1"             443   || failed=1
+# OTLP export (gRPC :4317) to an arbitrary peer: the collector ships telemetry
+# to a cross-namespace or remote backend, always allowed on 4317/4318.
+assert_from allow otel-probe "otlp export :4317"    "$OTLP_IP"            4317  || failed=1
 # Same pods, wrong ports — netpol is port-specific for the otel scrape rules.
 assert_from deny  otel-probe "control-plane :8080"  "$CP_IP"              8080  || failed=1
 assert_from deny  otel-probe "harmony :8080"        "$HARMONY_IP"         8080  || failed=1


### PR DESCRIPTION
## Summary

Two chart-side NetworkPolicy fixes so enabling netpols via the single `networkPolicies.enabled` master switch works without breaking telemetry, and so the switch gates *all* policies.

- **otel-collector policy: allow OTLP export egress (TCP 4317 + 4318).** The collector's purpose is to ship telemetry, but the policy previously only allowed in-cluster scrape targets + internet `:443`. Every fluidstack env exports OTLP to a cross-namespace collector (`otel-collector.otel`, and `datadog` for preprod) on `:4317`, which the policy silently blocked. Now rendered unconditionally as port-restricted `0.0.0.0/0` on 4317/4318 (same shape as the existing internet-egress helper, no `except`, to avoid the EKS Auto Mode cross-rule bleed).
- **recipe-runner policy on by default under the master switch.** `recipeRunner.networkPolicy.enabled` now defaults `true`, matching the other four components, so a single `networkPolicies.enabled: true` renders all five chart NetworkPolicies. It still renders only when the master switch is on and is individually disableable. Egress posture is unchanged: `recipeRunner.allowInternetEgress` stays `false` by default (untrusted recipe code), to be enabled per-env for workloads that need `pip install` / dataset pulls.
- Chart `0.53.3` -> `0.53.4`, UPGRADE.md note, regenerated TOC.

No change to any policy's egress posture defaults; this only adds the OTLP allow rule and flips one render gate. Gated installs (gator/customers) are unaffected until they set `networkPolicies.enabled: true`.

## Test coverage added

- **Dynamic (`test-sandkasten-netpol.sh`):** new `otlp-target` pod on `:4317` and an `otel-probe -> otlp-target:4317` **allow** assertion, proving the OTLP export path is open (the otel group previously only covered scrape ports + `:443`).
- **`test-values-netpol.yaml`:** dropped the explicit `recipeRunner.networkPolicy.enabled: true` so the master switch alone must render the recipe-runner policy, exercising the new default.
- **Static (`static-check-netpol.sh`):** unchanged by design. np-guard models `0.0.0.0/0` as an external range (not pod edges), so the OTLP rule doesn't alter workload-to-workload topology and the existing otel deny assertions still hold.

## Test Plan

- [x] `helm lint ./charts/adaptive`
- [x] `kubeconform -strict`: 35/35 valid, 0 errors
- [x] `helm template --set networkPolicies.enabled=true` renders all 5 policies from the single switch
- [x] Render with `test-values-netpol.yaml` (recipe-runner via default): all 5 render; otel policy has 4317 + 4318
- [ ] CI: ct lint + `netpol-static-check` + `netpol-test` matrix (Cilium/Calico/Antrea), incl. the new OTLP `:4317` assertion

## Follow-up (separate k8s-infrastructure PR)

Per-env enablement once `0.53.4` publishes: bump each fluidstack env to `0.53.4` and set `networkPolicies.enabled: true` (the one flag). preprod/staging additionally need control-plane egress to external RDS `:5432`, and recipe-running envs set `recipeRunner.networkPolicy.allowInternetEgress: true`. Staged in adaptive-ml-ops/k8s-infrastructure#1565.