### PR TITLE
fix(netpol): close egress gaps - operator-spawned pods, mlflow, apiserver/OTLP on Cilium [0.53.5]

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,8 @@
 - [Upgrade Guide](#upgrade-guide)
   - [0.53.4 to 0.53.5](#0534-to-0535)
     - [control-plane NetworkPolicy now allows egress to operator-spawned pods](#control-plane-networkpolicy-now-allows-egress-to-operator-spawned-pods)
+    - [harmony NetworkPolicy now allows egress to MLflow](#harmony-networkpolicy-now-allows-egress-to-mlflow)
+    - [otel-collector now gets a kube-apiserver CiliumNetworkPolicy](#otel-collector-now-gets-a-kube-apiserver-ciliumnetworkpolicy)
     - [otel-collector OTLP export egress now works on Cilium](#otel-collector-otlp-export-egress-now-works-on-cilium)
   - [0.53.x to 0.53.4](#053x-to-0534)
     - [otel-collector NetworkPolicy now allows OTLP export (:4317 / :4318)](#otel-collector-networkpolicy-now-allows-otlp-export-4317--4318)
@@ -37,6 +39,14 @@ This document describes breaking changes between Helm chart versions and how to 
 ### control-plane NetworkPolicy now allows egress to operator-spawned pods
 
 The control-plane egress policy only matched pods carrying the chart's harmony selector labels. Pods the control-plane spawns at runtime (inference partitions, harmony / recipe-runner gangs) are labeled `adaptive.ml/managed-by=control-plane` instead, so the control-plane could not reach their mangrove port (`:50053`) and inference partitions never finished registration. A rule matching `adaptive.ml/managed-by: control-plane` is now always included. No configuration change required.
+
+### harmony NetworkPolicy now allows egress to MLflow
+
+When `mlflow.enabled` is true the chart sets `MLFLOW_TRACKING_URI` on the harmony statefulset, and the Python training processes inside harmony pods log job metrics there. The harmony egress policy previously denied this, so metric logging to in-cluster MLflow was dropped under netpol. A rule matching the mlflow selector labels is now emitted when `mlflow.enabled` is true. No configuration change required.
+
+### otel-collector now gets a kube-apiserver CiliumNetworkPolicy
+
+The collector's prometheus receiver discovers scrape targets through the kube-apiserver (`kubernetes_sd_configs`). On Cilium the apiserver identity is not covered by the policy's TCP/443 internet rule, so target discovery (and therefore all metrics scraping) silently failed there. The chart now renders a `CiliumNetworkPolicy` with `toEntities: [kube-apiserver]` for the otel-collector, mirroring the existing control-plane one: auto-detected via the `cilium.io/v2` API group, a no-op on other CNIs, and opt-out via `otelCollector.networkPolicy.ciliumApiServerAllow.enabled: false`.
 
 ### otel-collector OTLP export egress now works on Cilium
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,9 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Upgrade Guide](#upgrade-guide)
+  - [0.53.4 to 0.53.5](#0534-to-0535)
+    - [control-plane NetworkPolicy now allows egress to operator-spawned pods](#control-plane-networkpolicy-now-allows-egress-to-operator-spawned-pods)
+    - [otel-collector OTLP export egress now works on Cilium](#otel-collector-otlp-export-egress-now-works-on-cilium)
   - [0.53.x to 0.53.4](#053x-to-0534)
     - [otel-collector NetworkPolicy now allows OTLP export (:4317 / :4318)](#otel-collector-networkpolicy-now-allows-otlp-export-4317--4318)
     - [recipe-runner NetworkPolicy now on by default under the master switch](#recipe-runner-networkpolicy-now-on-by-default-under-the-master-switch)
@@ -28,6 +31,16 @@
 # Upgrade Guide
 
 This document describes breaking changes between Helm chart versions and how to migrate your configuration.
+
+## 0.53.4 to 0.53.5
+
+### control-plane NetworkPolicy now allows egress to operator-spawned pods
+
+The control-plane egress policy only matched pods carrying the chart's harmony selector labels. Pods the control-plane spawns at runtime (inference partitions, harmony / recipe-runner gangs) are labeled `adaptive.ml/managed-by=control-plane` instead, so the control-plane could not reach their mangrove port (`:50053`) and inference partitions never finished registration. A rule matching `adaptive.ml/managed-by: control-plane` is now always included. No configuration change required.
+
+### otel-collector OTLP export egress now works on Cilium
+
+The OTLP export allow added in 0.53.4 used an `ipBlock: 0.0.0.0/0` rule, which on Cilium does NOT cover in-cluster pod IPs, so the collector could not reach a cross-namespace in-cluster collector (e.g. `otel-collector.otel`, `datadog`) on `:4317` there. The rule is now identity-based: a `namespaceSelector` matching all namespaces except the release's own (so it does not widen lateral reach to sibling components), plus an `ipBlock: 0.0.0.0/0` for external/SaaS backends. No configuration change required.
 
 ## 0.53.x to 0.53.4
 

--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.53.4
+version: 0.53.5
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/control-plane-networkpolicy.yaml
+++ b/charts/adaptive/templates/control-plane-networkpolicy.yaml
@@ -39,6 +39,16 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "adaptive.harmony.selectorLabels" . | nindent 14 }}
+    # Operator-spawned pods (inference partitions, harmony / recipe-runner
+    # gangs) — created dynamically by the control-plane and labeled
+    # adaptive.ml/managed-by=control-plane rather than with the chart's
+    # selector labels, so the harmony rule above does not match them. The
+    # control-plane connects to their mangrove port (50053) to accept
+    # compute-pool registration, same as for the static harmony workers.
+    - to:
+        - podSelector:
+            matchLabels:
+              adaptive.ml/managed-by: control-plane
     {{- if .Values.redis.install.enabled }}
     # Redis — caching / session store. Only emitted when the chart deploys
     # internal Redis. For external Redis (redis.install.enabled=false) the

--- a/charts/adaptive/templates/harmony-networkpolicy.yaml
+++ b/charts/adaptive/templates/harmony-networkpolicy.yaml
@@ -44,6 +44,17 @@ spec:
             matchLabels:
               {{- include "adaptive.otelCollector.selectorLabels" . | nindent 14 }}
     {{- end }}
+    {{- if .Values.mlflow.enabled }}
+    # MLflow — the Python training processes inside harmony pods log job
+    # metrics via MLFLOW_TRACKING_URI (adaptive_harmony metric_logger),
+    # which the chart wires onto the harmony statefulset when MLflow is
+    # deployed. Harmony is the only pod that gets that env var, so this is
+    # the only place the rule is needed.
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "adaptive.mlflow.selectorLabels" . | nindent 14 }}
+    {{- end }}
     {{- if .Values.minio.enabled }}
     # Internal MinIO — workers pull base models / write checkpoints to the
     # shared S3 bucket. Only emitted when the chart deploys it. For external

--- a/charts/adaptive/templates/otel-collector-cilium-networkpolicy.yaml
+++ b/charts/adaptive/templates/otel-collector-cilium-networkpolicy.yaml
@@ -1,0 +1,34 @@
+{{- /*
+Cilium-specific CNP that allows otel-collector egress to the kube-apiserver
+identity. The collector's prometheus receiver discovers scrape targets via
+`kubernetes_sd_configs`, which talks to the apiserver. On most CNIs the
+policy's TCP/443 internet rule covers that, but Cilium treats the apiserver
+as a distinct identity NOT covered by `ipBlock 0.0.0.0/0` (same caveat as
+the control-plane policy), so without this CNP target discovery — and
+therefore all metrics scraping — silently fails on Cilium clusters.
+
+Gated on the cluster having the `cilium.io/v2` API group registered, so on
+non-Cilium CNIs this file renders to nothing. To opt out on a Cilium
+cluster, set `otelCollector.networkPolicy.ciliumApiServerAllow.enabled: false`.
+*/ -}}
+{{- if and .Values.networkPolicies.enabled
+       .Values.otelCollector.enabled
+       .Values.otelCollector.networkPolicy.enabled
+       (.Values.otelCollector.networkPolicy.ciliumApiServerAllow.enabled)
+       (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "adaptive.otelCollector.fullname" . }}-cilium-apiserver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adaptive.labels" . | nindent 4 }}
+    {{- include "adaptive.otelCollector.selectorLabels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "adaptive.otelCollector.selectorLabels" . | nindent 6 }}
+  egress:
+    - toEntities:
+        - kube-apiserver
+{{- end }}

--- a/charts/adaptive/templates/otel-collector-networkpolicy.yaml
+++ b/charts/adaptive/templates/otel-collector-networkpolicy.yaml
@@ -45,14 +45,29 @@ spec:
         - protocol: TCP
           port: 4318
     {{- end }}
-    # OTLP export. Shipping telemetry is the collector's purpose, so allow
-    # OTLP gRPC :4317 and HTTP :4318 egress unconditionally. The backend may
-    # be an in-cluster collector in another namespace (e.g. otel-collector.otel,
-    # datadog) or a remote SaaS. Port-restricted 0.0.0.0/0 (no `except`, to
-    # avoid the EKS Auto Mode cross-rule bleed).
-    {{- include "adaptive.networkPolicy.internetEgress"
-          (dict "ports" (list (dict "port" 4317 "protocol" "TCP") (dict "port" 4318 "protocol" "TCP")))
-        | nindent 4 }}
+    # OTLP export (gRPC :4317 / HTTP :4318). Shipping telemetry is the
+    # collector's purpose, so allow it unconditionally to:
+    #   - in-cluster collectors in OTHER namespaces (otel-collector.otel,
+    #     datadog, ...) via a namespaceSelector. This is identity-based, which
+    #     Cilium requires: an ipBlock 0.0.0.0/0 rule does NOT cover in-cluster
+    #     pod IPs on Cilium. The release's own namespace is excluded so this
+    #     does not widen lateral reach to sibling components.
+    #   - external / SaaS backends via ipBlock 0.0.0.0/0 (port-restricted, no
+    #     `except`, to avoid the EKS Auto Mode cross-rule bleed).
+    - to:
+        - namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - {{ .Release.Namespace }}
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 4317
+        - protocol: TCP
+          port: 4318
     {{- if $hasRestrictive }}
     # restrictiveEgressRules is set — the user is taking control of the
     # otel-collector's external egress. The default permissive internet rule

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -765,6 +765,16 @@ otelCollector:
     # this explicit list — e.g. only the IP range of your observability
     # backend. In-cluster allow rules are not affected.
     restrictiveEgressRules: []
+    # When true (the default), and the cluster has the `cilium.io/v2` API
+    # group registered, the chart renders a CiliumNetworkPolicy allowing
+    # otel-collector egress to the kube-apiserver identity. The collector's
+    # prometheus receiver discovers scrape targets via kubernetes_sd, and
+    # on Cilium the apiserver is NOT covered by the TCP/443 internet rule
+    # (same caveat as the control-plane policy). On non-Cilium CNIs this is
+    # a no-op. Set to false if you ship your own admin-tier
+    # CiliumNetworkPolicy for the apiserver.
+    ciliumApiServerAllow:
+      enabled: true
 
   # Prometheus scraping configuration
   # Scrapes metrics from pods with annotation: prometheus.io/scrape: "adaptive"

--- a/scripts/static-check-netpol.sh
+++ b/scripts/static-check-netpol.sh
@@ -143,8 +143,11 @@ assert_allow         harmony-default controlplane    || failed=1
 assert_allow         harmony-default redis           || failed=1
 assert_allow         harmony-default otel-collector  || failed=1
 assert_internet_allow harmony-default                || failed=1
+# Python training processes inside harmony pods log to MLflow via
+# MLFLOW_TRACKING_URI, which the chart sets on the harmony statefulset
+# when mlflow is enabled — so this must be allow, not deny.
+assert_allow         harmony-default mlflow          || failed=1
 assert_deny          harmony-default sandkasten      || failed=1
-assert_deny          harmony-default mlflow          || failed=1
 assert_deny          harmony-default postgresql      || failed=1
 endgroup
 

--- a/scripts/static-check-netpol.sh
+++ b/scripts/static-check-netpol.sh
@@ -31,6 +31,35 @@ helm template "$RELEASE" "$CHART_DIR" \
   --namespace "$NS" \
   > "$WORKDIR/manifests.yaml"
 echo "rendered $(wc -l < "$WORKDIR/manifests.yaml") lines"
+
+# Synthetic operator-spawned workload. Inference partitions / gangs are
+# created at runtime by the control-plane with adaptive.ml/* labels (not the
+# chart's selector labels) and never appear in the rendered manifests, so
+# inject one for the reachability analysis.
+cat > "$WORKDIR/partition.yaml" <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${RELEASE}-inference-partition
+  namespace: $NS
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: inference-partition
+      adaptive.ml/managed-by: control-plane
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: inference-partition
+        adaptive.ml/managed-by: control-plane
+    spec:
+      containers:
+        - name: mangrove
+          image: busybox
+          ports:
+            - containerPort: 50053
+EOF
 endgroup
 
 group "Compute reachability (netpolicy list)"
@@ -103,6 +132,10 @@ assert_internet_allow controlplane                   || failed=1
 # (health-checks the worker service port). Without it registration is
 # rejected with a 500 and the pool never comes up.
 assert_allow         controlplane    harmony-default || failed=1
+# Same registration flow for operator-spawned partitions/gangs, which carry
+# adaptive.ml/managed-by=control-plane instead of the chart harmony labels.
+# Missing this rule broke preprod inference partitions (PS-4870).
+assert_allow         controlplane    inference-partition || failed=1
 endgroup
 
 group "harmony egress"

--- a/scripts/test-sandkasten-netpol.sh
+++ b/scripts/test-sandkasten-netpol.sh
@@ -46,7 +46,8 @@ if kubectl api-resources --api-group=cilium.io 2>/dev/null \
   IS_CILIUM=true
   HELM_API_ARGS+=(--api-versions cilium.io/v2)
   POLICIES+=(control-plane-cilium-networkpolicy.yaml)
-  echo "  Cilium CRDs detected -> also rendering control-plane-cilium-networkpolicy.yaml"
+  POLICIES+=(otel-collector-cilium-networkpolicy.yaml)
+  echo "  Cilium CRDs detected -> also rendering the control-plane and otel-collector Cilium apiserver CNPs"
 fi
 
 group "Render NetworkPolicies from chart"
@@ -326,7 +327,9 @@ assert_from allow harmony-probe "control-plane"      "$CP_IP"       8080 || fail
 assert_from allow harmony-probe "redis"              "$REDIS_IP"    8080 || failed=1
 assert_from allow harmony-probe "otel-collector"     "$OTEL_IP"     8080 || failed=1
 assert_from allow harmony-probe "internet (1.1.1.1)" "1.1.1.1"      443  || failed=1
-assert_from deny  harmony-probe "mlflow"             "$MLFLOW_IP"   8080 || failed=1
+# Training processes inside harmony pods log to MLflow (MLFLOW_TRACKING_URI
+# is set on the harmony statefulset when mlflow is enabled).
+assert_from allow harmony-probe "mlflow"             "$MLFLOW_IP"   8080 || failed=1
 assert_from deny  harmony-probe "sandkasten"         "$SAND_IP"     8080 || failed=1
 assert_from deny  harmony-probe "postgres"           "$PG_IP"       8080 || failed=1
 assert_from deny  harmony-probe "kubernetes API"     "$KUBE_API_IP" 443  || failed=1
@@ -347,8 +350,16 @@ assert_from deny  otel-probe "sandkasten"           "$SAND_IP"            8080  
 assert_from deny  otel-probe "postgres"             "$PG_IP"              8080  || failed=1
 assert_from deny  otel-probe "redis"                "$REDIS_IP"           8080  || failed=1
 assert_from deny  otel-probe "mlflow"               "$MLFLOW_IP"          8080  || failed=1
-assert_from deny  otel-probe "kubernetes API"       "$KUBE_API_IP"        443   || failed=1
 assert_from deny  otel-probe "unrelated"            "$OTHER_IP"           8080  || failed=1
+# otel -> kube-apiserver: required by the prometheus receiver's
+# kubernetes_sd target discovery. Same asymmetry as the cp assertion
+# above: on Cilium the chart's otel CNP (toEntities: [kube-apiserver])
+# allows it identity-based, so assert allow; on Calico / Antrea the kind
+# :6443 remap defeats the chart's 0.0.0.0/0:443 rule, so no assertion
+# (test-env artifact, not a chart gap).
+if [[ "$IS_CILIUM" == "true" ]]; then
+  assert_from allow otel-probe "kubernetes API"     "$KUBE_API_IP"        443   || failed=1
+fi
 endgroup
 
 group "recipe-runner egress (harmony-gang WS, cp/otel/mlflow, DNS, internet)"

--- a/scripts/test-sandkasten-netpol.sh
+++ b/scripts/test-sandkasten-netpol.sh
@@ -144,6 +144,32 @@ EOF
   # carries BOTH operator labels the policy podSelector matches.
   make_pod harmony-gang-target  harmony-gang   50053
   make_pod harmony-gang-8080    harmony-gang   8080
+  # Operator-spawned inference partition: carries ONLY the adaptive.ml/*
+  # operator labels (no chart name/instance labels), like the real pods the
+  # control-plane creates at runtime. Listens on the mangrove port (50053)
+  # the control-plane must reach for registration (PS-4870).
+  cat <<EOF
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: partition-target
+  namespace: $NS
+  labels:
+    app.kubernetes.io/component: inference-partition
+    adaptive.ml/managed-by: control-plane
+spec:
+  restartPolicy: Never
+  containers:
+    - name: main
+      image: $TARGET_IMAGE
+      command: ["httpd", "-f", "-p", "50053"]
+      ports:
+        - containerPort: 50053
+      readinessProbe:
+        tcpSocket: { port: 50053 }
+        periodSeconds: 2
+EOF
   cat <<EOF
 ---
 apiVersion: v1
@@ -183,6 +209,7 @@ OTHER_IP=$(get_ip other-target)
 OTLP_IP=$(get_ip otlp-target)
 HGANG_IP=$(get_ip harmony-gang-target)
 HGANG8080_IP=$(get_ip harmony-gang-8080)
+PARTITION_IP=$(get_ip partition-target)
 KUBE_API_IP=$(kubectl get svc -n default kubernetes -o jsonpath='{.spec.clusterIP}')
 
 # `nc -zv` returns 0 on connect, non-zero on refused/timeout. We wrap in
@@ -244,6 +271,8 @@ assert_from allow cp-probe "internet (1.1.1.1)"   "1.1.1.1"      443  || failed=
 # Without this the pool registration is rejected with a 500 and the pool
 # never comes up.
 assert_from allow cp-probe "harmony"              "$HARMONY_IP"  8080 || failed=1
+# Operator-spawned partition (adaptive.ml/managed-by label, no chart labels).
+assert_from allow cp-probe "inference partition"  "$PARTITION_IP" 50053 || failed=1
 assert_from deny  cp-probe "unrelated"            "$OTHER_IP"    8080 || failed=1
 # cp → kube-apiserver reachability.
 #

--- a/scripts/test-sandkasten-netpol.sh
+++ b/scripts/test-sandkasten-netpol.sh
@@ -135,9 +135,6 @@ EOF
   make_pod redis-target         redis          8080
   make_pod mlflow-target        mlflow         8080
   make_pod other-target         unrelated      8080
-  # OTLP backend on :4317 to prove the otel-collector's OTLP export egress
-  # (always-on 4317/4318 to any destination) renders and is allowed.
-  make_pod otlp-target          otlp-backend   4317
   # Recipe-runner pod-only isolation (HAR-162). One harmony-gang target listens
   # on the allowed WS port (50053) and another on a non-allowed port (8080) so
   # the deny assertion proves a policy drop, not a connection-refused. The probe
@@ -191,7 +188,36 @@ spec:
 EOF
 } | kubectl apply -f -
 
+# OTLP backend in a SEPARATE namespace. The otel OTLP-export rule is scoped via
+# namespaceSelector to namespaces other than the release's own, so a cross-
+# namespace target is what proves it (and Cilium needs identity-based matching,
+# not ipBlock). Mirrors otel-collector.otel / datadog in real environments.
+OTLP_NS="${NS}-otlp"
+kubectl create namespace "$OTLP_NS" --dry-run=client -o yaml | kubectl apply -f -
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: otlp-target
+  namespace: $OTLP_NS
+  labels:
+    app.kubernetes.io/component: otlp-backend
+spec:
+  restartPolicy: Never
+  containers:
+    - name: main
+      image: $TARGET_IMAGE
+      command: ["httpd", "-f", "-p", "4317"]
+      ports:
+        - containerPort: 4317
+      readinessProbe:
+        tcpSocket: { port: 4317 }
+        periodSeconds: 2
+EOF
+
 kubectl wait --for=condition=Ready pod --all -n "$NS" --timeout=180s
+kubectl wait --for=condition=Ready pod otlp-target -n "$OTLP_NS" --timeout=180s
 endgroup
 
 get_ip() { kubectl get pod -n "$NS" "$1" -o jsonpath='{.status.podIP}'; }
@@ -206,7 +232,7 @@ PG_IP=$(get_ip postgres-target)
 REDIS_IP=$(get_ip redis-target)
 MLFLOW_IP=$(get_ip mlflow-target)
 OTHER_IP=$(get_ip other-target)
-OTLP_IP=$(get_ip otlp-target)
+OTLP_IP=$(kubectl get pod -n "$OTLP_NS" otlp-target -o jsonpath='{.status.podIP}')
 HGANG_IP=$(get_ip harmony-gang-target)
 HGANG8080_IP=$(get_ip harmony-gang-8080)
 PARTITION_IP=$(get_ip partition-target)


### PR DESCRIPTION
Part of HAR-162. Fixes the preprod netpol regression (PS-4870) plus three more egress gaps found by a flow-matrix audit of all five policies.

## 1. control-plane egress to operator-spawned pods (PS-4870, broke preprod)

The control-plane egress policy only allowed pods carrying the chart harmony selector labels. Operator-spawned pods (inference partitions, harmony / recipe-runner gangs) carry `adaptive.ml/managed-by=control-plane` instead ( `k8s-operator/src/adapters/k8s/consts.rs`), and `:50053` is in no ipBlock rule, so concorde -> mangrove registration was dropped when netpol went live on preprod (k8s-infrastructure#1565; mitigated by revert #1568). Fix: unconditional egress rule matching `adaptive.ml/managed-by: control-plane`.

## 2. harmony egress to MLflow

The chart sets `MLFLOW_TRACKING_URI` on the harmony statefulset when `mlflow.enabled`, and its only consumer is `adaptive_harmony/metric_logger.py`, which runs in the Python training processes inside harmony pods. The harmony policy (and our own test assertions) denied it, silently dropping job metric logging. Fix: conditional mlflow rule when `mlflow.enabled`.

## 3. otel-collector -> kube-apiserver on Cilium

The prometheus receiver uses `kubernetes_sd_configs`, which needs the apiserver. Cilium does not cover the apiserver identity via `ipBlock 0.0.0.0/0:443`, so target discovery (hence all scraping) silently fails there. Fix: a `CiliumNetworkPolicy` with `toEntities: [kube-apiserver]` mirroring the control-plane one, gated on `cilium.io/v2` detection, opt-out via `otelCollector.networkPolicy.ciliumApiServerAllow.enabled: false` (new value, default true).

## 4. otel OTLP export egress works on Cilium

Follow-up to #161 (merged at the pre-fix commit): the 0.53.4 OTLP allow used `ipBlock 0.0.0.0/0`, which Cilium does not apply to in-cluster pod IPs. The rule is now identity-based: `namespaceSelector` for all namespaces except the release's own, plus ipBlock for external SaaS backends.

## Test coverage

- Static check: synthetic operator-labeled partition Deployment, `controlplane => inference-partition` allow (fails on 0.53.4); `harmony-default => mlflow` flipped deny -> allow.
- Dynamic CNI matrix (Cilium/Calico/Antrea): `partition-target` with only operator labels reachable from cp-probe on :50053; `harmony-probe => mlflow` allow; `otel-probe => kube API :443` allow on the Cilium leg (passes only because of the new CNP); OTLP backend in a separate namespace for the cross-namespace path.

## Test Plan

- [x] `helm lint`, TOC check, `bash -n` on both scripts
- [x] Render checks: mlflow rule present, otel CNP renders only with `--api-versions cilium.io/v2`
- [ ] CI: `netpol-static-check` + `netpol-test` matrix (Cilium/Calico/Antrea)

## Downstream

After this publishes as `0.53.5`: re-enable netpol on the fluidstack envs (re-apply the reverted #1565 values + pin chart `0.53.5`).
