### PR TITLE
fix(harmony): apply harmony egress NetworkPolicy to operator-spawned pods

### DIFF
--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.53.5
+version: 0.53.6
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/_helpers.tpl
+++ b/charts/adaptive/templates/_helpers.tpl
@@ -953,6 +953,114 @@ Usage:
 {{- end }}
 {{- end }}
 
+{{/*
+Harmony egress rules — shared by the chart-managed harmony StatefulSets
+(component=harmony) and the operator-spawned pods that run the same workload
+but carry control-plane labels instead of the chart's name/instance selector
+labels (component=harmony-gang for gang training jobs, component=inference-
+partition for serving). All of them run the mangrove preflight and need the
+identical egress set: cluster DNS, the control plane, internal
+Redis/MLflow/MinIO/s3proxy when the chart deploys them, and public-internet
+(external S3 / Huggingface) on internetEgressPorts.
+
+Keeping this in one place is what stops the operator-pod policy from drifting
+away from the harmony policy — they must allow the same destinations.
+
+Call with a dict:
+  ctx  - root chart context (.)
+  gang - bool; true emits the operator-pod self/peer selector
+         (component in {harmony-gang, inference-partition}), false the
+         chart harmony selector.
+*/}}
+{{- define "adaptive.harmony.egressRules" -}}
+{{- $ctx := .ctx -}}
+{{- $np := $ctx.Values.harmony.networkPolicy -}}
+{{- $hasRestrictive := gt (len $np.restrictiveEgressRules) 0 -}}
+# Cluster DNS.
+{{- include "adaptive.networkPolicy.dnsEgress" $ctx | nindent 0 }}
+# Self: harmony workers within a compute pool talk over the headless service.
+- to:
+    - podSelector:
+        {{- if .gang }}
+        matchExpressions:
+          - key: app.kubernetes.io/component
+            operator: In
+            values:
+              - harmony-gang
+              - inference-partition
+        matchLabels:
+          adaptive.ml/managed-by: control-plane
+        {{- else }}
+        matchLabels:
+          {{- include "adaptive.harmony.selectorLabels" $ctx | nindent 10 }}
+        {{- end }}
+# Control plane — workers report status / pull config via CONTROL_PLANE_URL.
+- to:
+    - podSelector:
+        matchLabels:
+          {{- include "adaptive.controlPlane.selectorLabels" $ctx | nindent 10 }}
+{{- if $ctx.Values.redis.install.enabled }}
+# Redis — workers hit it during preflight (mangrove::preflight Redis
+# check) and at runtime for inter-worker coordination on gang-spawned
+# jobs. Only emitted when the chart deploys internal Redis. For
+# external Redis, allow its IP/CIDR via restrictiveEgressRules.
+- to:
+    - podSelector:
+        matchLabels:
+          {{- include "adaptive.redis.selectorLabels" $ctx | nindent 10 }}
+{{- end }}
+{{- if $ctx.Values.otelCollector.enabled }}
+- to:
+    - podSelector:
+        matchLabels:
+          {{- include "adaptive.otelCollector.selectorLabels" $ctx | nindent 10 }}
+{{- end }}
+{{- if $ctx.Values.mlflow.enabled }}
+# MLflow — the Python training processes inside harmony pods log job
+# metrics via MLFLOW_TRACKING_URI (adaptive_harmony metric_logger),
+# which the chart wires onto the harmony statefulset when MLflow is
+# deployed. Harmony is the only pod that gets that env var, so this is
+# the only place the rule is needed.
+- to:
+    - podSelector:
+        matchLabels:
+          {{- include "adaptive.mlflow.selectorLabels" $ctx | nindent 10 }}
+{{- end }}
+{{- if $ctx.Values.minio.enabled }}
+# Internal MinIO — workers pull base models / write checkpoints to the
+# shared S3 bucket. Only emitted when the chart deploys it. For external
+# S3, allow the endpoint via restrictiveEgressRules.
+- to:
+    - podSelector:
+        matchLabels:
+          {{- include "adaptive.minio.selectorLabels" $ctx | nindent 10 }}
+{{- end }}
+{{- if $ctx.Values.s3proxy.enabled }}
+# Internal s3proxy: S3 API in front of external blob storage (Azure Blob,
+# GCS, ...). When deployed, workers pull base models / write checkpoints
+# through it instead of MinIO. Only emitted when the chart deploys it; for
+# direct external S3 use restrictiveEgressRules.
+- to:
+    - podSelector:
+        matchLabels:
+          {{- include "adaptive.s3proxy.selectorLabels" $ctx | nindent 10 }}
+{{- end }}
+{{- if $hasRestrictive }}
+# restrictiveEgressRules is set — the user is taking control of harmony's
+# external egress. The default permissive internet rule is suppressed;
+# only the rules below (and the in-cluster allows above) apply.
+{{- toYaml $np.restrictiveEgressRules | nindent 0 }}
+{{- else if $np.allowInternetEgress }}
+# External egress on the listed ports (TCP/443 + TCP/80 by default) —
+# workers pull base models from Huggingface and other external model
+# registries. Port-restricted to public protocols so this rule does NOT
+# widen access to in-cluster pods on other ports.
+{{- include "adaptive.networkPolicy.internetEgress"
+      (dict "ports" $np.internetEgressPorts)
+    | nindent 0 }}
+{{- end }}
+{{- end }}
+
 {{- define "adaptive.recipeRunner.fullname" -}}
 {{- printf "%s-recipe-runner" (include "adaptive.fullname" .) | trunc 40 | trimSuffix "-" }}
 {{- end}}

--- a/charts/adaptive/templates/harmony-networkpolicy.yaml
+++ b/charts/adaptive/templates/harmony-networkpolicy.yaml
@@ -1,6 +1,4 @@
 {{- if and .Values.networkPolicies.enabled .Values.harmony.networkPolicy.enabled }}
-{{- $np := .Values.harmony.networkPolicy }}
-{{- $hasRestrictive := gt (len $np.restrictiveEgressRules) 0 }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -16,76 +14,37 @@ spec:
   policyTypes:
     - Egress
   egress:
-    # Cluster DNS.
-    {{- include "adaptive.networkPolicy.dnsEgress" . | nindent 4 }}
-    # Self: harmony workers within a compute pool talk over the headless service.
-    - to:
-        - podSelector:
-            matchLabels:
-              {{- include "adaptive.harmony.selectorLabels" . | nindent 14 }}
-    # Control plane — workers report status / pull config via CONTROL_PLANE_URL.
-    - to:
-        - podSelector:
-            matchLabels:
-              {{- include "adaptive.controlPlane.selectorLabels" . | nindent 14 }}
-    {{- if .Values.redis.install.enabled }}
-    # Redis — workers hit it during preflight (mangrove::preflight Redis
-    # check) and at runtime for inter-worker coordination on gang-spawned
-    # jobs. Only emitted when the chart deploys internal Redis. For
-    # external Redis, allow its IP/CIDR via restrictiveEgressRules.
-    - to:
-        - podSelector:
-            matchLabels:
-              {{- include "adaptive.redis.selectorLabels" . | nindent 14 }}
-    {{- end }}
-    {{- if .Values.otelCollector.enabled }}
-    - to:
-        - podSelector:
-            matchLabels:
-              {{- include "adaptive.otelCollector.selectorLabels" . | nindent 14 }}
-    {{- end }}
-    {{- if .Values.mlflow.enabled }}
-    # MLflow — the Python training processes inside harmony pods log job
-    # metrics via MLFLOW_TRACKING_URI (adaptive_harmony metric_logger),
-    # which the chart wires onto the harmony statefulset when MLflow is
-    # deployed. Harmony is the only pod that gets that env var, so this is
-    # the only place the rule is needed.
-    - to:
-        - podSelector:
-            matchLabels:
-              {{- include "adaptive.mlflow.selectorLabels" . | nindent 14 }}
-    {{- end }}
-    {{- if .Values.minio.enabled }}
-    # Internal MinIO — workers pull base models / write checkpoints to the
-    # shared S3 bucket. Only emitted when the chart deploys it. For external
-    # S3, allow the endpoint via restrictiveEgressRules.
-    - to:
-        - podSelector:
-            matchLabels:
-              {{- include "adaptive.minio.selectorLabels" . | nindent 14 }}
-    {{- end }}
-    {{- if .Values.s3proxy.enabled }}
-    # Internal s3proxy: S3 API in front of external blob storage (Azure Blob,
-    # GCS, ...). When deployed, workers pull base models / write checkpoints
-    # through it instead of MinIO. Only emitted when the chart deploys it; for
-    # direct external S3 use restrictiveEgressRules.
-    - to:
-        - podSelector:
-            matchLabels:
-              {{- include "adaptive.s3proxy.selectorLabels" . | nindent 14 }}
-    {{- end }}
-    {{- if $hasRestrictive }}
-    # restrictiveEgressRules is set — the user is taking control of harmony's
-    # external egress. The default permissive internet rule is suppressed;
-    # only the rules below (and the in-cluster allows above) apply.
-    {{- toYaml $np.restrictiveEgressRules | nindent 4 }}
-    {{- else if $np.allowInternetEgress }}
-    # External egress on the listed ports (TCP/443 + TCP/80 by default) —
-    # workers pull base models from Huggingface and other external model
-    # registries. Port-restricted to public protocols so this rule does NOT
-    # widen access to in-cluster pods on other ports.
-    {{- include "adaptive.networkPolicy.internetEgress"
-          (dict "ports" $np.internetEgressPorts)
-        | nindent 4 }}
-    {{- end }}
+    {{- include "adaptive.harmony.egressRules" (dict "ctx" . "gang" false) | nindent 4 }}
+---
+# Operator-spawned harmony pods. The control plane creates gang training pods
+# (component=harmony-gang) and inference serving pods (component=inference-
+# partition) per job; they carry control-plane labels, NOT the chart's
+# name/instance selector labels, so the harmony podSelector above does not match
+# them. They run the same workload (mangrove preflight + training/serving) and
+# need the same egress. Selecting them with an Egress policy is also what keeps
+# the otel DDOT CiliumClusterwideNetworkPolicy from leaving them default-deny on
+# everything except the Datadog agent.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "adaptive.harmony.fullname" . }}-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adaptive.labels" . | nindent 4 }}
+    {{- include "adaptive.sharedSelectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: harmony-gang
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+          - harmony-gang
+          - inference-partition
+    matchLabels:
+      adaptive.ml/managed-by: control-plane
+  policyTypes:
+    - Egress
+  egress:
+    {{- include "adaptive.harmony.egressRules" (dict "ctx" . "gang" true) | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
## What

The harmony egress `NetworkPolicy` selects `app.kubernetes.io/component=harmony` plus the chart's `name`/`instance` labels. The control plane spawns two kinds of pod that run the same workload but carry control-plane labels instead, so the policy never matched them:

- **`component=harmony-gang`** — gang training pods
- **`component=inference-partition`** — inference serving pods

Both had no egress `NetworkPolicy` at all.

## Why it broke

That gap was harmless until the otel DDOT `CiliumClusterwideNetworkPolicy` (`adaptive-otlp-ddot-egress`) began selecting these components to allow Datadog agent egress. In Cilium, once an endpoint is selected by **any** egress policy it flips to **default-deny egress** — so the gang/inference pods could reach only the Datadog agent on 4317/4318.

Harmony gang pods then failed the mangrove S3 preflight (write to `s3://.../model_registry`) with an HTTP connect timeout and exited 1:

```
Error while calling put_object: DispatchFailure { kind: Timeout, HttpTimeoutError { kind: "HTTP connect", duration: 3.1s }}
Error: "Preflight checks failed: Failed to write to S3: dispatch failure"
```

`recipe-runner-gang` was unaffected because it already has its own hand-written gang `NetworkPolicy`; chart-managed `harmony`/`control-plane`/`sandkasten` were unaffected because their pods carry the chart selector labels.

## Change

- Extract the harmony egress rules into a shared template (`adaptive.harmony.egressRules`) so the operator-pod policy cannot drift from the harmony policy.
- Emit a second `NetworkPolicy` selecting `component in {harmony-gang, inference-partition}` with `adaptive.ml/managed-by=control-plane`, granting the same egress: cluster DNS, control plane, internal Redis/MLflow/MinIO/s3proxy when deployed, and public-internet (external S3 / Huggingface) on `internetEgressPorts`.
- Bump chart version `0.53.5` → `0.53.6`.

## Validation

- The chart-managed harmony policy renders **byte-identical** to before (verified by diffing `helm template` output).
- `helm lint` passes; `kubectl apply --dry-run=server` accepts both policies.
- Exercised the `minio`, `s3proxy`, and `restrictiveEgressRules` value branches — each emits the rule in both policies and suppresses internet egress as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)