### PR TITLE
test(netpol): CI guard for operator-spawned pod egress coverage

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -185,6 +185,13 @@ jobs:
       - name: Static reachability check
         run: ./scripts/static-check-netpol.sh
 
+      - name: Operator-pod egress coverage check
+        # Asserts the chart emits egress for operator-spawned pods
+        # (harmony-gang, inference-partition). Reachability analysis can't
+        # cover them — they have no workload object in the chart — so this is
+        # a separate structural check over the rendered manifests.
+        run: ./scripts/check-operator-pod-egress.sh
+
   netpol-test:
     # Dynamic NetworkPolicy enforcement test across multiple CNIs. Each
     # matrix entry stands up a fresh kind cluster, installs the CNI,

--- a/scripts/check-operator-pod-egress.py
+++ b/scripts/check-operator-pod-egress.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Assert every operator-spawned pod component has chart egress coverage.
+
+Reads a rendered `helm template` manifest (multi-doc YAML) and checks that
+each control-plane-managed component listed in REQUIRED_COMPONENTS is selected
+by an Egress NetworkPolicy that grants the destinations its mangrove preflight
+needs (cluster DNS, the control plane, and an S3 path).
+
+Source of truth for the component list is the otel DDOT
+CiliumClusterwideNetworkPolicy (k8s-infrastructure) — the policy that selects
+these pods in production and flips them to default-deny. Any component it
+selects must appear here and get chart egress, or the build fails.
+"""
+
+import sys
+
+import yaml
+
+COMPONENT_LABEL = "app.kubernetes.io/component"
+MANAGED_BY_LABEL = "adaptive.ml/managed-by"
+MANAGED_BY_VALUE = "control-plane"
+
+# Operator-spawned components that carry control-plane labels instead of the
+# chart selector labels. Keep in sync with the DDOT clusterwide policy.
+REQUIRED_COMPONENTS = ["harmony-gang", "inference-partition"]
+
+# S3 / external object storage is reachable either via the internal
+# s3proxy/minio services or directly over the internet (external S3 / HF).
+S3_COMPONENTS = {"s3proxy", "minio"}
+INTERNET_CIDR = "0.0.0.0/0"
+
+
+def pod_selector_matches(selector: dict, component: str) -> bool:
+    """True if a podSelector targets `component` AND is scoped to control-plane managed pods."""
+    if not selector:
+        return False
+    labels = selector.get("matchLabels") or {}
+    if labels.get(MANAGED_BY_LABEL) != MANAGED_BY_VALUE:
+        return False
+    if labels.get(COMPONENT_LABEL) == component:
+        return True
+    for expr in selector.get("matchExpressions") or []:
+        if (
+            expr.get("key") == COMPONENT_LABEL
+            and expr.get("operator") == "In"
+            and component in (expr.get("values") or [])
+        ):
+            return True
+    return False
+
+
+def egress_targets_component(egress: list, component: str) -> bool:
+    for rule in egress or []:
+        for to in rule.get("to") or []:
+            sel = to.get("podSelector") or {}
+            if (sel.get("matchLabels") or {}).get(COMPONENT_LABEL) == component:
+                return True
+    return False
+
+
+def egress_has_dns(egress: list) -> bool:
+    for rule in egress or []:
+        for port in rule.get("ports") or []:
+            if port.get("port") == 53:
+                return True
+    return False
+
+
+def egress_has_s3(egress: list) -> bool:
+    for rule in egress or []:
+        for to in rule.get("to") or []:
+            block = to.get("ipBlock") or {}
+            if block.get("cidr") == INTERNET_CIDR and any(
+                p.get("port") in (443, 80) for p in rule.get("ports") or []
+            ):
+                return True
+            sel = to.get("podSelector") or {}
+            if (sel.get("matchLabels") or {}).get(COMPONENT_LABEL) in S3_COMPONENTS:
+                return True
+    return False
+
+
+def main(path: str) -> int:
+    with open(path) as f:
+        policies = [
+            d
+            for d in yaml.safe_load_all(f)
+            if d and d.get("kind") == "NetworkPolicy"
+        ]
+
+    failed = False
+    for component in REQUIRED_COMPONENTS:
+        print(f"::group::Operator-pod egress coverage: {component}")
+        matching = [
+            p
+            for p in policies
+            if "Egress" in (p.get("spec", {}).get("policyTypes") or [])
+            and pod_selector_matches(p.get("spec", {}).get("podSelector", {}), component)
+        ]
+        if not matching:
+            print(
+                f"  FAIL no Egress NetworkPolicy selects component={component} "
+                f"with {MANAGED_BY_LABEL}={MANAGED_BY_VALUE}"
+            )
+            print("::endgroup::")
+            failed = True
+            continue
+
+        # Coverage is the union of every policy that selects the component
+        # (NetworkPolicy egress is additive).
+        egress = [r for p in matching for r in (p["spec"].get("egress") or [])]
+        names = ", ".join(p["metadata"]["name"] for p in matching)
+        print(f"  selected by: {names}")
+
+        checks = {
+            "cluster DNS": egress_has_dns(egress),
+            "control plane": egress_targets_component(egress, "control-plane"),
+            "S3 (internet :443/:80 or s3proxy/minio)": egress_has_s3(egress),
+        }
+        for label, ok in checks.items():
+            print(f"  [{'ok' if ok else 'FAIL'}] egress to {label}")
+            failed = failed or not ok
+        print("::endgroup::")
+
+    if failed:
+        print("\n✗ operator-pod egress coverage check failed", file=sys.stderr)
+        return 1
+    print("\nAll operator-pod egress coverage assertions passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: check-operator-pod-egress.py <rendered-manifests.yaml>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))

--- a/scripts/check-operator-pod-egress.sh
+++ b/scripts/check-operator-pod-egress.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Assert the chart emits an egress NetworkPolicy for every operator-spawned
+# pod component.
+#
+# The control plane spawns pods that run the harmony workload but carry
+# control-plane labels (adaptive.ml/managed-by=control-plane) instead of the
+# chart's name/instance selector labels:
+#   - app.kubernetes.io/component=harmony-gang        (gang training)
+#   - app.kubernetes.io/component=inference-partition (inference serving)
+#
+# These have no workload object in the chart, so the dynamic CNI matrix and
+# the np-guard reachability check (both workload-driven) never see them. They
+# only acquire a NetworkPolicy if the chart selects them by label.
+#
+# Why this matters: as soon as ANY egress policy selects one of these pods it
+# flips to default-deny egress (vanilla NetworkPolicy and Cilium both). In
+# production the otel DDOT CiliumClusterwideNetworkPolicy selects them to allow
+# Datadog agent egress, which silently turned their egress default-deny and
+# broke the mangrove S3 preflight (gang pods exited 1 on an S3 connect
+# timeout). The fix is the chart granting these components the same egress as
+# harmony. This check fails the build if that coverage regresses or if a new
+# operator-spawned component is added without it.
+#
+# Pure static analysis over `helm template` output; no cluster needed.
+
+set -euo pipefail
+
+CHART_DIR="${CHART_DIR:-./charts/adaptive}"
+RELEASE="${RELEASE:-adaptive-test}"
+NS="${NS:-netpol-test}"
+VALUES_BASE="${VALUES_BASE:-.github/test-values-base.yaml}"
+VALUES_NETPOL="${VALUES_NETPOL:-.github/test-values-netpol.yaml}"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+printf '::group::Render chart\n'
+helm template "$RELEASE" "$CHART_DIR" \
+  -f "$VALUES_BASE" -f "$VALUES_NETPOL" \
+  --namespace "$NS" \
+  > "$WORKDIR/manifests.yaml"
+echo "rendered $(wc -l < "$WORKDIR/manifests.yaml") lines"
+printf '::endgroup::\n'
+
+python3 "$(dirname "$0")/check-operator-pod-egress.py" "$WORKDIR/manifests.yaml"


### PR DESCRIPTION
## What

Adds a static CI check that fails the build if an operator-spawned pod component lacks egress NetworkPolicy coverage. Wired into the existing `netpol-static-check` job.

- `scripts/check-operator-pod-egress.py` — parses `helm template` output; for each operator-spawned component (`harmony-gang`, `inference-partition`) asserts an Egress NetworkPolicy selects it (`adaptive.ml/managed-by=control-plane`) and grants cluster DNS + control plane + an S3 path (internet :443/:80 or s3proxy/minio).
- `scripts/check-operator-pod-egress.sh` — render-then-analyze wrapper, mirrors `static-check-netpol.sh`.
- one step added to `netpol-static-check` in `lint-test.yml`.

## Why

This is the regression guard for the bug fixed in #164. Operator-spawned pods carry control-plane labels, not the chart's selector labels, so they had no egress policy. Once the otel DDOT `CiliumClusterwideNetworkPolicy` started selecting them they went default-deny and failed the mangrove S3 preflight.

Existing CI couldn't catch it:
- The e2e reachability recipe runs in `recipe-runner-gang` (own netpol, unaffected) and is deny-side only.
- The np-guard reachability check and kind CNI matrix are workload-driven; these pods have no workload object in the chart.
- The k3s e2e gang test has no clusterwide policy selecting these pods, so they stay default-allow and the bug doesn't reproduce.

This check reasons about the policy selectors directly, so it sees pods with no workload object, and runs in seconds with no cluster.

## Validation

- Passes on current `main` (post-#164).
- Fails on pre-#164 `main` with `no Egress NetworkPolicy selects component=harmony-gang with adaptive.ml/managed-by=control-plane`.
- `shellcheck` clean; `python3 -m py_compile` clean.

## Note

The required-component list is hardcoded; its source of truth is the DDOT `CiliumClusterwideNetworkPolicy` in k8s-infrastructure. A new operator-spawned component added to that selector must also be added here. Documented in the script headers.

Closes HAR-173.