### PR TITLE
fix(otel): use standard prometheus.io/scrape: "true" annotation [0.53.7]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ harmony:
 
 The OTel Collector scrapes Prometheus metrics from Adaptive components via annotations:
 ```yaml
-prometheus.io/scrape: "adaptive"
+prometheus.io/scrape: "true"
 prometheus.io/path: /metrics
 prometheus.io/port: "50053"  # harmony / "9009" for control-plane
 ```

--- a/README.md
+++ b/README.md
@@ -1218,7 +1218,7 @@ The collector configuration includes fixed receivers and processors that cannot 
 
 - **Receivers**:
   - OTLP HTTP on port `4318`
-  - Prometheus scraper for pods with annotation `prometheus.io/scrape: "adaptive"`
+  - Prometheus scraper for pods with annotation `prometheus.io/scrape: "true"`
 - **Processors**: `batch`, `memory_limiter`, and `resource` (for adding resource attributes)
 
 You can adjust the memory limiter and Prometheus scraping settings:
@@ -1238,7 +1238,7 @@ The collector automatically scrapes Prometheus metrics from pods in the same nam
 
 ```yaml
 annotations:
-  prometheus.io/scrape: "adaptive"  # Required - enables scraping
+  prometheus.io/scrape: "true"  # Required - enables scraping
   prometheus.io/path: "/metrics"    # Optional - metrics endpoint path (default: /metrics)
   prometheus.io/port: "9090"        # Optional - metrics port
 ```

--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.53.6
+version: 0.53.7
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/otel-collector-confmap.yaml
+++ b/charts/adaptive/templates/otel-collector-confmap.yaml
@@ -25,10 +25,10 @@ data:
                   namespaces:
                     own_namespace: true
               relabel_configs:
-                # Only scrape pods with prometheus.io/scrape: "adaptive" annotation
+                # Only scrape pods with prometheus.io/scrape: "true" annotation
                 - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
                   action: keep
-                  regex: adaptive
+                  regex: "true"
                 # Use custom path if specified
                 - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
                   action: replace

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -175,7 +175,7 @@ harmony:
 
   podAnnotations:
     ingest-adaptive-logs: "true"
-    prometheus.io/scrape: "adaptive"
+    prometheus.io/scrape: "true"
     prometheus.io/path: /metrics
     prometheus.io/port: "50053"
   podLabels: {}
@@ -445,7 +445,7 @@ controlPlane:
   annotations: {}
   podAnnotations:
     ingest-adaptive-logs: "true"
-    prometheus.io/scrape: "adaptive"
+    prometheus.io/scrape: "true"
     prometheus.io/path: /metrics
     prometheus.io/port: "9009"
   podLabels: {}
@@ -777,7 +777,7 @@ otelCollector:
       enabled: true
 
   # Prometheus scraping configuration
-  # Scrapes metrics from pods with annotation: prometheus.io/scrape: "adaptive"
+  # Scrapes metrics from pods with annotation: prometheus.io/scrape: "true"
   prometheus:
     scrapeInterval: "15s"
 


### PR DESCRIPTION
## What

Change the Prometheus scrape annotation value from `"adaptive"` to the community-standard `"true"`.

- `charts/adaptive/values.yaml` — scrape annotation on harmony and control-plane pods
- `charts/adaptive/templates/otel-collector-confmap.yaml` — the OTel collector relabel rule (`action: keep`) matched on `regex: adaptive`; updated to `regex: "true"` so scraping stays in sync with the annotation
- `README.md`, `CLAUDE.md` — doc references
- `charts/adaptive/Chart.yaml` — version bumped `0.53.6` → `0.53.7`

The relabel-rule change is required: the annotation value alone is meaningless without the matching `keep` regex, so changing one without the other would stop the collector from scraping any pods.

## Test

`helm template` renders cleanly — harmony and control-plane pods emit `prometheus.io/scrape: "true"` and the relabel rule emits `regex: "true"`.

## Note

If any external/operator-managed scrapers in a deployment were keyed to the old `adaptive` value, they will need updating too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)