### PR TITLE
feat(harmony): move harmony ports from 500xx to 200xx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ The OTel Collector scrapes Prometheus metrics from Adaptive components via annot
 ```yaml
 prometheus.io/scrape: "adaptive"
 prometheus.io/path: /metrics
-prometheus.io/port: "50053"  # harmony / "9009" for control-plane
+prometheus.io/port: "20053"  # harmony / "9009" for control-plane
 ```
 
 ## CI/CD

--- a/charts/adaptive/Chart.yaml
+++ b/charts/adaptive/Chart.yaml
@@ -2,7 +2,7 @@ name: adaptive
 description: Helm Chart for Adaptive Engine
 kubeVersion: ">=1.28.0-0"
 type: application
-version: 0.53.6
+version: 0.53.7
 apiVersion: v2
 appVersion: "1.0"
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAXVBMVEXt6ujv6+fr6+fv6enr6efv79/p6ent6+jU0s9ZVlNAPTqjoJ3g3tu7ubavrarHxcMnJCEzMC00MS6WlJFyb2xMSUaKh4SKiIV+e3jIxsNxbmtlYl9lY2Dh39xNSkednTH/AAAAB3RSTlO/QEAwkBAwtdHlmAAAAK9JREFUeF7N00cSgzAMBVCnSq6Fnnr/YyYEbDFBZs1fafFmrDIWp8NmLkLAZo67A/iQ3zSmCJrwS18COszBAlAJSB7okGNZMBBwLMAqAVXooUtAF8Br7rIFDhjvwU0gekT8AyjHp7VBxIFGJXCr0g5p2prAYkWW6mgIuJByhzrXPYEuAwUqg8iBN0jCBCw9sag116QHeNJJuTHpJLheVDvdwMkx9WrVFvf7cc5iM9cPZL8jDpv6dmsAAAAASUVORK5CYII=

--- a/charts/adaptive/templates/_helpers.tpl
+++ b/charts/adaptive/templates/_helpers.tpl
@@ -270,9 +270,9 @@ Harmony ports
 */}}
 {{- define "adaptive.harmony.ports" -}}
 {
-  "http": {"name": "http", "containerPort": 50053, "port": 80},
-  "queue": {"name": "queue", "containerPort": 50052},
-  "tcpstore": {"name": "tcpstore", "containerPort": 50054},
+  "http": {"name": "http", "containerPort": 20053, "port": 80},
+  "queue": {"name": "queue", "containerPort": 20052},
+  "tcpstore": {"name": "tcpstore", "containerPort": 20054},
   "torch": {"name": "torch", "containerPort": 7777}
 }
 {{- end }}

--- a/charts/adaptive/templates/control-plane-networkpolicy.yaml
+++ b/charts/adaptive/templates/control-plane-networkpolicy.yaml
@@ -30,10 +30,10 @@ spec:
               {{- include "adaptive.sandkasten.selectorLabels" . | nindent 14 }}
     # Harmony (mangrove) — control-plane health-checks and orchestrates the
     # harmony workers. Each compute pool registers with the control-plane,
-    # which then connects back to the worker's service port (50053 health,
+    # which then connects back to the worker's service port (20053 health,
     # plus the gang/control ports) to accept the registration. Without this
     # rule the registration is rejected with a 500 ("Cannot reach Mangrove
-    # at …:50053") and the compute pool never comes up. Harmony is a core
+    # at …:20053") and the compute pool never comes up. Harmony is a core
     # component (always deployed), so this is unconditional.
     - to:
         - podSelector:
@@ -43,7 +43,7 @@ spec:
     # gangs) — created dynamically by the control-plane and labeled
     # adaptive.ml/managed-by=control-plane rather than with the chart's
     # selector labels, so the harmony rule above does not match them. The
-    # control-plane connects to their mangrove port (50053) to accept
+    # control-plane connects to their mangrove port (20053) to accept
     # compute-pool registration, same as for the static harmony workers.
     - to:
         - podSelector:

--- a/charts/adaptive/templates/harmony-statefulset.yaml
+++ b/charts/adaptive/templates/harmony-statefulset.yaml
@@ -139,6 +139,8 @@ spec:
               value: "{{ $gpusPerReplica | default 1 }}"
             - name: MASTER_ADDR
               value: "{{ include "adaptive.harmony.computePool.fullname" (dict "root" $root "pool" $pool) }}-0.{{ include "adaptive.harmony.computePool.headlessService.fullname" (dict "root" $root "pool" $pool) }}"
+            - name: HTTP_PORT
+              value: "{{ $ports.http.containerPort }}"
             - name: MASTER_PORT
               value: "{{ $ports.torch.containerPort }}"
             - name: QUEUE_PORT

--- a/charts/adaptive/templates/otel-collector-networkpolicy.yaml
+++ b/charts/adaptive/templates/otel-collector-networkpolicy.yaml
@@ -33,7 +33,7 @@ spec:
               {{- include "adaptive.harmony.selectorLabels" . | nindent 14 }}
       ports:
         - protocol: TCP
-          port: 50053
+          port: 20053
     {{- if .Values.lgtm.enabled }}
     # LGTM stack — OTLP export endpoint (4318) when running the all-in-one
     # in-cluster observability stack.

--- a/charts/adaptive/templates/recipe-runner-networkpolicy.yaml
+++ b/charts/adaptive/templates/recipe-runner-networkpolicy.yaml
@@ -23,7 +23,7 @@ spec:
   egress:
     # Cluster DNS — needed for in-cluster Service names and external hostnames.
     {{- include "adaptive.networkPolicy.dnsEgress" . | nindent 4 }}
-    # Harmony gang master — the runner's HARMONY_WS_ENDPOINT (ws://...:50053).
+    # Harmony gang master — the runner's HARMONY_WS_ENDPOINT (ws://...:20053).
     # The master pod is operator-created with component=harmony-gang.
     - to:
         - podSelector:
@@ -31,7 +31,7 @@ spec:
               app.kubernetes.io/component: harmony-gang
       ports:
         - protocol: TCP
-          port: 50053
+          port: 20053
     # Control plane (Concorde) — recipes call it via ADAPTIVE_CONTROL_PLANE_URL.
     - to:
         - podSelector:

--- a/charts/adaptive/values.yaml
+++ b/charts/adaptive/values.yaml
@@ -177,7 +177,7 @@ harmony:
     ingest-adaptive-logs: "true"
     prometheus.io/scrape: "adaptive"
     prometheus.io/path: /metrics
-    prometheus.io/port: "50053"
+    prometheus.io/port: "20053"
   podLabels: {}
   extraEnvVars: {}
   # GPU tolerations - only applied when requireGpu is true (default)
@@ -734,7 +734,7 @@ otelCollector:
     # maxUnavailable: 1
 
   # NetworkPolicy for the otel-collector. Always renders allow rules for its
-  # Prometheus scrape targets (control-plane :9009, harmony :50053), cluster
+  # Prometheus scrape targets (control-plane :9009, harmony :20053), cluster
   # DNS, and the in-cluster LGTM stack on :4318 when enabled. External
   # egress is permissive by default so the collector can ship telemetry to
   # remote observability backends (Datadog, Grafana Cloud, ...) without

--- a/scripts/static-check-netpol.sh
+++ b/scripts/static-check-netpol.sh
@@ -58,7 +58,7 @@ spec:
         - name: mangrove
           image: busybox
           ports:
-            - containerPort: 50053
+            - containerPort: 20053
 EOF
 endgroup
 

--- a/scripts/test-sandkasten-netpol.sh
+++ b/scripts/test-sandkasten-netpol.sh
@@ -17,7 +17,7 @@ VALUES_BASE="${VALUES_BASE:-.github/test-values-base.yaml}"
 VALUES_NETPOL="${VALUES_NETPOL:-.github/test-values-netpol.yaml}"
 PROBE_IMAGE="${PROBE_IMAGE:-nicolaka/netshoot:v0.13}"
 # busybox httpd binds to any port we ask for; useful when targets need to
-# listen on the otel scrape ports (9009, 50053) in addition to the default.
+# listen on the otel scrape ports (9009, 20053) in addition to the default.
 TARGET_IMAGE="${TARGET_IMAGE:-busybox:1.36}"
 NC_TIMEOUT="${NC_TIMEOUT:-5}"
 
@@ -129,7 +129,7 @@ EOF
   make_pod cp-target            control-plane  8080
   make_pod cp-metrics-target    control-plane  9009
   make_pod harmony-target       harmony        8080
-  make_pod harmony-metrics-tgt  harmony        50053
+  make_pod harmony-metrics-tgt  harmony        20053
   make_pod otel-target          otel-collector 8080
   make_pod sandkasten-target    sandkasten     8080
   make_pod postgres-target      postgresql     8080
@@ -137,14 +137,14 @@ EOF
   make_pod mlflow-target        mlflow         8080
   make_pod other-target         unrelated      8080
   # Recipe-runner pod-only isolation (HAR-162). One harmony-gang target listens
-  # on the allowed WS port (50053) and another on a non-allowed port (8080) so
+  # on the allowed WS port (20053) and another on a non-allowed port (8080) so
   # the deny assertion proves a policy drop, not a connection-refused. The probe
   # carries BOTH operator labels the policy podSelector matches.
-  make_pod harmony-gang-target  harmony-gang   50053
+  make_pod harmony-gang-target  harmony-gang   20053
   make_pod harmony-gang-8080    harmony-gang   8080
   # Operator-spawned inference partition: carries ONLY the adaptive.ml/*
   # operator labels (no chart name/instance labels), like the real pods the
-  # control-plane creates at runtime. Listens on the mangrove port (50053)
+  # control-plane creates at runtime. Listens on the mangrove port (20053)
   # the control-plane must reach for registration (PS-4870).
   cat <<EOF
 ---
@@ -161,11 +161,11 @@ spec:
   containers:
     - name: main
       image: $TARGET_IMAGE
-      command: ["httpd", "-f", "-p", "50053"]
+      command: ["httpd", "-f", "-p", "20053"]
       ports:
-        - containerPort: 50053
+        - containerPort: 20053
       readinessProbe:
-        tcpSocket: { port: 50053 }
+        tcpSocket: { port: 20053 }
         periodSeconds: 2
 EOF
   cat <<EOF
@@ -299,7 +299,7 @@ assert_from allow cp-probe "internet (1.1.1.1)"   "1.1.1.1"      443  || failed=
 # never comes up.
 assert_from allow cp-probe "harmony"              "$HARMONY_IP"  8080 || failed=1
 # Operator-spawned partition (adaptive.ml/managed-by label, no chart labels).
-assert_from allow cp-probe "inference partition"  "$PARTITION_IP" 50053 || failed=1
+assert_from allow cp-probe "inference partition"  "$PARTITION_IP" 20053 || failed=1
 assert_from deny  cp-probe "unrelated"            "$OTHER_IP"    8080 || failed=1
 # cp → kube-apiserver reachability.
 #
@@ -338,7 +338,7 @@ endgroup
 
 group "otel-collector egress (scrape ports, DNS, internet)"
 assert_from allow otel-probe "control-plane :9009"  "$CP_METRICS_IP"      9009  || failed=1
-assert_from allow otel-probe "harmony :50053"       "$HARMONY_METRICS_IP" 50053 || failed=1
+assert_from allow otel-probe "harmony :20053"       "$HARMONY_METRICS_IP" 20053 || failed=1
 assert_from allow otel-probe "internet (1.1.1.1)"   "1.1.1.1"             443   || failed=1
 # OTLP export (gRPC :4317) to an arbitrary peer: the collector ships telemetry
 # to a cross-namespace or remote backend, always allowed on 4317/4318.
@@ -363,8 +363,8 @@ fi
 endgroup
 
 group "recipe-runner egress (harmony-gang WS, cp/otel/mlflow, DNS, internet)"
-# The runner's WS endpoint is the gang master on :50053.
-assert_from allow recipe-runner-probe "harmony-gang :50053" "$HGANG_IP"  50053 || failed=1
+# The runner's WS endpoint is the gang master on :20053.
+assert_from allow recipe-runner-probe "harmony-gang :20053" "$HGANG_IP"  20053 || failed=1
 assert_from allow recipe-runner-probe "control-plane"       "$CP_IP"     8080  || failed=1
 assert_from allow recipe-runner-probe "otel-collector"      "$OTEL_IP"   8080  || failed=1
 assert_from allow recipe-runner-probe "mlflow"              "$MLFLOW_IP" 8080  || failed=1


### PR DESCRIPTION
Change the three harmony ports (queue, http/mangrove, tcpstore) from
50052/50053/50054 to 20052/20053/20054. The torch port (7777) is
unchanged.

The ports are defined once in the adaptive.harmony.ports helper, which
drives the StatefulSet containerPorts, the headless Service, and the
harmony app's QUEUE_PORT / TCP_STORE_PORT / ADVERTISED_URL env vars.
The http port (20053) is also referenced directly by the otel-collector
and recipe-runner NetworkPolicy egress rules, the harmony prometheus
scrape annotation, and the CI netpol guard scripts; all move in lockstep.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
